### PR TITLE
plscope_identifiers: fix procedure_scope in case of forward decl. + other fixes/chg

### DIFF
--- a/database/utils/view/plscope_identifiers.sql
+++ b/database/utils/view/plscope_identifiers.sql
@@ -377,7 +377,6 @@ create or replace view plscope_identifiers as
           refs.object_name                as ref_object_name,     -- decl_object_name
           regexp_replace(src.text, chr(10) 
                || '+$', null)             as text,  -- remove trailing new line character
-          stmt.full_text                  as sql_fulltext,
           tree.parent_statement_type,
           tree.parent_statement_signature,
           tree.parent_statement_path_len,
@@ -454,15 +453,10 @@ create or replace view plscope_identifiers as
           tree.origin_con_id
      from tree_plus tree,
           dba_identifiers refs,
-          src,
-          dba_statements stmt
+          src
     where refs.signature (+) = tree.signature
       and refs.usage (+)     = 'DECLARATION'
       and src.owner (+)      = tree.owner
       and src.type (+)       = tree.object_type
       and src.name (+)       = tree.object_name
-      and src.line (+)       = tree.line
-      and stmt.owner (+)         = tree.owner
-      and stmt.sql_id (+)        = tree.name
-      and stmt.signature (+)     = tree.signature
-      and stmt.origin_con_id (+) = tree.origin_con_id;
+      and src.line (+)       = tree.line;

--- a/database/utils/view/plscope_identifiers.sql
+++ b/database/utils/view/plscope_identifiers.sql
@@ -374,8 +374,9 @@ create or replace view plscope_identifiers as
           tree.path_len,
           tree.type,
           case
-             when tree.usage = 'SQL_ID' then  -- make SQL_ID pseudo-usage appear as SQL_STMT
-                'SQL_STMT'
+             -- make SQL_ID and SQL_STMT pseudo-usages appear as EXECUTE
+             when tree.usage in ('SQL_ID', 'SQL_STMT') then
+                'EXECUTE'
              else
                  tree.usage
           end                             as usage,

--- a/database/utils/view/plscope_identifiers.sql
+++ b/database/utils/view/plscope_identifiers.sql
@@ -27,6 +27,7 @@ create or replace view plscope_identifiers as
           where owner like nvl(sys_context('PLSCOPE', 'OWNER'), user)
             and type like nvl(sys_context('PLSCOPE', 'OBJECT_TYPE'), '%')
             and name like nvl(sys_context('PLSCOPE', 'OBJECT_NAME'), '%')
+            and origin_con_id = sys_context('USERENV', 'CON_ID')
       ),
       pls_ids as (
          select owner,
@@ -45,6 +46,7 @@ create or replace view plscope_identifiers as
           where owner like nvl(sys_context('PLSCOPE', 'OWNER'), user)
             and object_type like nvl(sys_context('PLSCOPE', 'OBJECT_TYPE'), '%')
             and object_name like nvl(sys_context('PLSCOPE', 'OBJECT_NAME'), '%')
+            and origin_con_id = sys_context('USERENV', 'CON_ID')
       ),
       sql_ids as (
          select owner,
@@ -63,6 +65,7 @@ create or replace view plscope_identifiers as
           where owner like nvl(sys_context('PLSCOPE', 'OWNER'), user)
             and object_type like nvl(sys_context('PLSCOPE', 'OBJECT_TYPE'), '%')
             and object_name like nvl(sys_context('PLSCOPE', 'OBJECT_NAME'), '%')
+            and origin_con_id = sys_context('USERENV', 'CON_ID')
       ),
       fids as (
          select 'NO'                               as is_sql_stmt,

--- a/database/utils/view/plscope_identifiers.sql
+++ b/database/utils/view/plscope_identifiers.sql
@@ -28,7 +28,7 @@ create or replace view plscope_identifiers as
             and type like nvl(sys_context('PLSCOPE', 'OBJECT_TYPE'), '%')
             and name like nvl(sys_context('PLSCOPE', 'OBJECT_NAME'), '%')
       ),
-      prep_ids as (
+      pls_ids as (
          select owner,
                 name,
                 signature,
@@ -42,23 +42,54 @@ create or replace view plscope_identifiers as
                 usage_context_id,
                 origin_con_id
            from dba_identifiers
-         union all
+          where owner like nvl(sys_context('PLSCOPE', 'OWNER'), user)
+            and object_type like nvl(sys_context('PLSCOPE', 'OBJECT_TYPE'), '%')
+            and object_name like nvl(sys_context('PLSCOPE', 'OBJECT_NAME'), '%')
+      ),
+      sql_ids as (
          select owner,
-                ':' || nvl(sql_id, type) as name,  -- intermediate statement marker colon
+                nvl(sql_id, type)  as name,
                 signature,
                 type,
                 object_name,
                 object_type,
-                'EXECUTE' as usage, -- new, artificial usage
+                'SQL_STMT'  as usage, -- new, artificial usage
                 usage_id,
                 line,
                 col,
                 usage_context_id,
                 origin_con_id
            from dba_statements
+          where owner like nvl(sys_context('PLSCOPE', 'OWNER'), user)
+            and object_type like nvl(sys_context('PLSCOPE', 'OBJECT_TYPE'), '%')
+            and object_name like nvl(sys_context('PLSCOPE', 'OBJECT_NAME'), '%')
       ),
       fids as (
-         select owner,
+         select 'NO'                               as is_sql_stmt,
+                a.owner,
+                a.name,
+                a.signature,
+                a.type,
+                a.object_name,
+                a.object_type,
+                a.usage,
+                a.usage_id,
+                a.line,
+                a.col,
+                a.usage_context_id,
+                nvl2(b.signature, 'PUBLIC', null)  as procedure_scope,
+                a.origin_con_id
+           from pls_ids a,
+                dba_identifiers b
+          where b.owner (+)         = a.owner
+            and b.object_type (+)   = 'PACKAGE'
+            and b.object_name (+)   = a.object_name
+            and b.usage (+)         = 'DECLARATION'
+            and b.signature (+)     = a.signature
+            and b.origin_con_id (+) = a.origin_con_id
+         union all
+         select 'YES'                              as is_sql_stmt,
+                owner,
                 name,
                 signature,
                 type,
@@ -69,14 +100,13 @@ create or replace view plscope_identifiers as
                 line,
                 col,
                 usage_context_id,
+                null                               as procedure_scope,
                 origin_con_id
-           from prep_ids
-          where owner like nvl(sys_context('PLSCOPE', 'OWNER'), user)
-            and object_type like nvl(sys_context('PLSCOPE', 'OBJECT_TYPE'), '%')
-            and object_name like nvl(sys_context('PLSCOPE', 'OBJECT_NAME'), '%')
+           from sql_ids
       ),
       base_ids as (
-         select fids.owner,
+         select fids.is_sql_stmt,
+                fids.owner,
                 fids.name,
                 fids.signature,
                 fids.type,
@@ -85,7 +115,7 @@ create or replace view plscope_identifiers as
                 fids.usage,
                 fids.usage_id,
                 case
-                   when fk.usage_id is not null
+                   when parent.usage_id is not null
                       or fids.usage_context_id = 0
                    then
                       'YES'
@@ -95,16 +125,18 @@ create or replace view plscope_identifiers as
                 fids.line,
                 fids.col,
                 fids.usage_context_id,
+                fids.procedure_scope,
                 fids.origin_con_id
-           from fids
-           left join fids fk
-             on fk.owner = fids.owner
-            and fk.object_type = fids.object_type
-            and fk.object_name = fids.object_name
-            and fk.usage_id = fids.usage_context_id
+           from fids,
+                fids parent
+          where parent.owner (+)       = fids.owner
+            and parent.object_type (+) = fids.object_type
+            and parent.object_name (+) = fids.object_name
+            and parent.usage_id (+)    = fids.usage_context_id
       ),
       ids as (
-         select owner,
+         select is_sql_stmt,
+                owner,
                 name,
                 signature,
                 type,
@@ -126,121 +158,184 @@ create or replace view plscope_identifiers as
                          order by line, col
                          rows between unbounded preceding and 1 preceding
                       )
-                end as usage_context_id, -- fix broken hierarchies
+                end  as usage_context_id,        -- fix broken hierarchies
+                case
+                   when sane_fk = 'NO' then
+                      'YES'
+                end  as is_fixed_context_id,     -- indicator of fixed hierarchies
+                procedure_scope,
                 origin_con_id
            from base_ids
       ),
-      tree as (
-         select ids.owner,
-                ids.object_type,
-                ids.object_name,
-                ids.line,
-                ids.col,
-                ids.name,
-                replace(sys_connect_by_path(ids.name, '|'), '|', '/') as name_path,
-                level as path_len,
-                ids.type,
-                ids.usage,
-                ids.signature,
-                ids.usage_id,
-                ids.usage_context_id,
-                ids.origin_con_id
+      tree (
+         owner,
+         object_type,
+         object_name,
+         line,
+         col,
+         procedure_name,
+         procedure_scope,
+         name,
+         name_path,
+         path_len,
+         type,
+         usage,
+         signature,
+         usage_id,
+         usage_context_id,
+         is_fixed_context_id,
+         procedure_signature,
+         is_sql_stmt,
+         parent_statement_type,
+         parent_statement_signature,
+         parent_statement_path_len,
+         origin_con_id
+      ) as (
+         select owner,
+                object_type,
+                object_name,
+                line,
+                col,
+                case
+                   when object_type in ('PROCEDURE', 'FUNCTION') then
+                      name
+                end                          as procedure_name,
+                case
+                   when object_type in ('PROCEDURE', 'FUNCTION') then
+                      'PUBLIC'
+                end                          as procedure_scope,
+                name,
+                '/' || name                  as name_path,
+                1                            as path_len,
+                type,
+                usage,
+                signature,
+                usage_id,
+                usage_context_id,
+                is_fixed_context_id,
+                case
+                   when object_type in ('PROCEDURE', 'FUNCTION') then
+                      signature
+                end                          as procedure_signature,
+                is_sql_stmt,
+                cast(null as varchar2(18))   as parent_statement_type,
+                cast(null as varchar2(32))   as parent_statement_signature,
+                cast(null as number)         as parent_statement_path_len,
+                origin_con_id
            from ids
-          start with ids.usage_context_id = 0
-        connect by prior ids.usage_id = ids.usage_context_id
-            and prior ids.owner = ids.owner
-            and prior ids.object_type = ids.object_type
-            and prior ids.object_name = ids.object_name
+          where usage_context_id = 0  -- top-level identifiers
+         union all
+         select b.owner,
+                b.object_type,
+                b.object_name,
+                b.line,
+                b.col,
+                case
+                   when a.procedure_name is not null then
+                      a.procedure_name
+                   when b.object_type in ('PACKAGE', 'PACKAGE BODY')
+                      and b.type in ('FUNCTION', 'PROCEDURE')
+                      and b.usage in ('DEFINITION', 'DECLARATION')
+                      and b.usage_context_id = 1
+                   then
+                      b.name
+                end                             as procedure_name,
+                case
+                   when a.procedure_scope is not null then
+                      a.procedure_scope
+                   when b.object_type = 'PACKAGE'
+                      and b.type in ('FUNCTION', 'PROCEDURE')
+                      and b.usage = 'DECLARATION'
+                      and b.usage_context_id = 1
+                   then
+                      'PUBLIC'
+                   when b.object_type = 'PACKAGE BODY'
+                      and b.type in ('FUNCTION', 'PROCEDURE')
+                      and b.usage in ('DEFINITION', 'DECLARATION')
+                      and b.usage_context_id = 1
+                   then
+                      decode(b.procedure_scope,
+                           'PUBLIC', 'PUBLIC',
+                           'PRIVATE')
+                end                             as procedure_scope,
+                b.name,
+                a.name_path || '/' || b.name    as name_path,
+                a.path_len + 1                  as path_len,
+                b.type,
+                b.usage,
+                b.signature,
+                b.usage_id,
+                b.usage_context_id,
+                b.is_fixed_context_id,
+                case
+                   when a.procedure_signature is not null then
+                      a.procedure_signature
+                   when b.object_type in ('PACKAGE', 'PACKAGE BODY')
+                      and b.type in ('FUNCTION', 'PROCEDURE')
+                      and b.usage in ('DEFINITION', 'DECLARATION')
+                      and b.usage_context_id = 1
+                   then
+                      b.signature
+                end                             as procedure_signature,
+                b.is_sql_stmt,
+                case
+                   when a.is_sql_stmt = 'YES' then
+                      a.type
+                   else
+                      a.parent_statement_type
+                end                             as parent_statement_type,
+                case
+                   when a.is_sql_stmt = 'YES' then
+                      a.signature
+                   else
+                      a.parent_statement_signature
+                end                             as parent_statement_signature,
+                case
+                   when a.is_sql_stmt = 'YES' then
+                      a.path_len
+                   else
+                      a.parent_statement_path_len
+                end                             as parent_statement_path_len,
+                b.origin_con_id
+           from tree a,
+                ids b
+          where a.owner       = b.owner
+            and a.object_type = b.object_type
+            and a.object_name = b.object_name
+            and a.usage_id    = b.usage_context_id
       )
-   select /*+use_hash(tree) use_hash(refs) */
-          tree.owner,
+   select tree.owner,
           tree.object_type,
           tree.object_name,
           tree.line,
           tree.col,
-          last_value (
-             case
-                when tree.type in ('PROCEDURE', 'FUNCTION')
-                   and tree.path_len = 2
-                then
-                   tree.name
-             end
-          ) ignore nulls over (
-             partition by tree.owner, tree.object_name, tree.object_type
-             order by tree.line, tree.col, tree.path_len
-          ) as procedure_name,
-          last_value (
-             case
-                when tree.object_type = 'PACKAGE BODY'
-                   and tree.type in ('PROCEDURE', 'FUNCTION')
-                   and tree.path_len = 2
-                then
-                   case tree.usage
-                      when 'DECLARATION' then
-                         'PRIVATE'
-                      when 'DEFINITION' then
-                         'PUBLIC'
-                   end
-             end
-          ) ignore nulls over (
-             partition by tree.owner, tree.object_name, tree.object_type
-             order by tree.line, tree.col, tree.path_len
-          ) as procedure_scope,
-          replace(tree.name, ':', null) as name, -- remove intermediate statement marker
-          replace(tree.name_path, ':', null) as name_path, -- remove intermediate statement marker
+          tree.procedure_name,
+          tree.procedure_scope,
+          lpad(' ', 2 * (tree.path_len - 1))
+                || case
+                      when tree.usage = 'SQL_STMT' then
+                         tree.type || ' statement (sql_id: ' || tree.name || ')'
+                      else
+                         tree.name || ' (' || lower(tree.type) || ' ' || lower(tree.usage) || ')'
+                   end                    as name_usage,
+          tree.name,
+          tree.name_path,
           tree.path_len,
           tree.type,
           tree.usage,
-          refs.owner as ref_owner,
-          refs.object_type as ref_object_type,
-          refs.object_name as ref_object_name,
-          regexp_replace(src.text, chr(10) || '+$', null) as text, -- remove trailing new line character
+          refs.owner                      as ref_owner,           -- decl_owner
+          refs.object_type                as ref_object_type,     -- decl_object_type
+          refs.object_name                as ref_object_name,     -- decl_object_name
+          regexp_replace(src.text, chr(10) 
+               || '+$', null)             as text,  -- remove trailing new line character
+          tree.parent_statement_type,
+          tree.parent_statement_signature,
+          tree.parent_statement_path_len,
           case
-             when tree.name_path like '%:%'
-                and tree.usage != 'EXECUTE'
-             then
-                -- ensure that this is really a child of a statement
-                last_value (
-                   case
-                      when tree.usage = 'EXECUTE' then
-                         tree.type
-                   end
-                ) ignore nulls over (
-                   partition by tree.owner, tree.object_name, tree.object_type
-                   order by tree.line, tree.col, tree.path_len
-                )
-          end as parent_statement_type,
-          case
-             when tree.name_path like '%:%'
-                and tree.usage != 'EXECUTE'
-             then
-                -- ensure that this is really a child of a statement
-                last_value (
-                   case
-                      when tree.usage = 'EXECUTE' then
-                         tree.signature
-                   end
-                ) ignore nulls over (
-                   partition by tree.owner, tree.object_name, tree.object_type
-                   order by tree.line, tree.col, tree.path_len
-                )
-          end as parent_statement_signature,
-          case
-             when tree.name_path like '%:%'
-                and tree.usage != 'EXECUTE'
-             then
-                -- ensure that this is really a child of a statement
-                last_value (
-                   case
-                      when tree.usage = 'EXECUTE' then
-                         tree.path_len
-                   end
-                ) ignore nulls over (
-                   partition by tree.owner, tree.object_name, tree.object_type
-                   order by tree.line, tree.col, tree.path_len
-                )
-          end as parent_statement_path_len,
-          case
+             -- wrong result, if used in statements which do not register usage, 
+             -- such as a variable for dynamic_sql_stmt in EXECUTE IMMEDIATE.
+             -- Bug 26351814.
+             --
              when tree.object_type in ('PACKAGE BODY', 'PROCEDURE', 'FUNCTION', 'TYPE BODY')
                 and tree.usage = 'DECLARATION'
                 and tree.type not in ('LABEL')
@@ -262,17 +357,21 @@ create or replace view plscope_identifiers as
                    else
                       'YES'
                 end
-          end as is_used, -- wrong result, if used in statements which do not register usage, such as a variable for dynamic_sql_stmt in EXECUTE IMMEDIATE. Bug 26351814.
+          end                             as is_used,
           tree.signature,
           tree.usage_id,
           tree.usage_context_id,
+          tree.is_fixed_context_id,
+          tree.procedure_signature,
+          refs.line                       as ref_line,         -- decl_line
+          refs.col                        as ref_col,          -- decl_col
           tree.origin_con_id
-     from tree
-     left join dba_identifiers refs
-       on refs.signature = tree.signature
-      and refs.usage = 'DECLARATION'
-     left join src
-       on src.owner = tree.owner
-      and src.type = tree.object_type
-      and src.name = tree.object_name
-      and src.line = tree.line;
+     from tree,
+          dba_identifiers refs,
+          src
+    where refs.signature (+) = tree.signature
+      and refs.usage (+)     = 'DECLARATION'
+      and src.owner (+)      = tree.owner
+      and src.type (+)       = tree.object_type
+      and src.name (+)       = tree.object_name
+      and src.line (+)       = tree.line;

--- a/database/utils/view/plscope_identifiers.sql
+++ b/database/utils/view/plscope_identifiers.sql
@@ -351,7 +351,8 @@ create or replace view plscope_identifiers as
       tree_plus as (                                                    --@formatter:off
          select tree.*,                                                    
                 case
-                   when usage = 'DEFINITION'
+                   when type in ('PROCEDURE', 'FUNCTION')
+                      and usage = 'DEFINITION'
                       and nvl( lag( procedure_signature,
                                     decode(is_def_child_of_decl, 'YES', 2, 'NO', 1)
                                ) over (


### PR DESCRIPTION
Hi,

Couple of proposed changes to the `PLSCOPE_IDENTIFIERS` view:

* A fix for `procedure_scope` not correctly taking into account forward-declared procedures/functions
* A fix for issue #34 (action 2: detect and work around the overflow)

(This involves rewriting the hierarchical `tree` subquery using recursive-with.)

Other changes:

* Added columns:
   * `name_usage`: name + type + usage (+ left indentation), in a single column for conveniently viewing the hierarchy, as a complement to `name_path`
   * `is_fixed_context_id`: `YES` if the value of `usage_context_id` was fixed in order to repair the broken hierarchy (for the current identifier), null otherwise
   * `procedure_signature`: the signature of the current top-level procedure (as in `procedure_name`, `procedure_scope`)
   * `ref_line`, `ref_col`: line and column where the identifier was originally declared, in the object identified by `ref_owner`, `ref_object_type`, and `ref_object_name`
   * `proc_ends_before_line`, `proc_ends_before_col`: upper bound of the position in the source code where a top-level procedure ends
* Added the following condition to filters against `DBA_SOURCE`, `DBA_IDENTIFIERS`, `DBA_STATEMENTS`: `origin_con_id = sys_context('USERENV', 'CON_ID')`

Unsure about the last one (commit: 06655d4) : perhaps it would be better to leave that to the new `CONTAINER_DATA` parameter (MOS Doc. id 2745111.1), but on the other hand not every DB has that patch.

In any case, the above are just suggestions; feel free to pick any or none of them, as you see fit.

Regards,