### PR TITLE
Bugfix/various fixes from pull request 38

### DIFF
--- a/database/test/package/test_dd_util.pkb
+++ b/database/test/package/test_dd_util.pkb
@@ -126,7 +126,7 @@ create or replace package body test_dd_util is
       -- fully qualified
       l_input  := obj_type(user, 'VIEW', 'PLSCOPE_IDENTIFIERS');
       l_actual := dd_util.get_view_source(l_input);
-      ut.expect(l_actual).to_match('^(WITH)(.+)$', 'n');
+      ut.expect(l_actual).to_match('^(WITH)(.+)$', 'ni');
       -- not fully qualified
       l_input  := obj_type(null, 'VIEW', 'PLSCOPE_IDENTIFIERS');
       l_actual := dd_util.get_view_source(l_input);

--- a/database/utils/view/plscope_identifiers.sql
+++ b/database/utils/view/plscope_identifiers.sql
@@ -393,7 +393,7 @@ create or replace view plscope_identifiers as
              else
                 tree.usage
           end as usage,
-          refs.owner as ref_owner,           -- decl_owner
+          refs.owner as ref_owner,                 -- decl_owner
           refs.object_type as ref_object_type,     -- decl_object_type
           refs.object_name as ref_object_name,     -- decl_object_name
           regexp_replace(src.text, chr(10) || '+$', null) as text,  -- remove trailing new line character
@@ -469,7 +469,7 @@ create or replace view plscope_identifiers as
                    1)
           end as proc_ends_before_col,
           refs.line as ref_line,         -- decl_line
-          refs.col as ref_col,          -- decl_col
+          refs.col as ref_col,           -- decl_col
           tree.origin_con_id
      from tree_plus tree
      left join dba_identifiers refs

--- a/database/utils/view/plscope_identifiers.sql
+++ b/database/utils/view/plscope_identifiers.sql
@@ -456,7 +456,8 @@ create or replace view plscope_identifiers as
           end as proc_ends_before_line,
           case
              when tree.is_new_proc = 'YES' then
-                nvl(first_value(
+                nvl(
+                   first_value(
                       case
                          when tree.is_new_proc = 'YES'
                             or tree.usage_context_id = 1
@@ -468,7 +469,8 @@ create or replace view plscope_identifiers as
                       order by tree.usage_id
                       rows between 1 following and unbounded following
                    ),
-                   1)
+                   1
+                )
           end as proc_ends_before_col,
           refs.line as ref_line,         -- decl_line
           refs.col as ref_col,           -- decl_col

--- a/database/utils/view/plscope_identifiers.sql
+++ b/database/utils/view/plscope_identifiers.sql
@@ -436,7 +436,8 @@ create or replace view plscope_identifiers as
           --tree.is_new_proc,             --uncomment if needed for debugging
           case
              when tree.is_new_proc = 'YES' then
-                nvl(first_value(
+                coalesce(
+                   first_value(
                       case
                          when tree.is_new_proc = 'YES'
                             or tree.usage_context_id = 1
@@ -450,7 +451,8 @@ create or replace view plscope_identifiers as
                    ),
                    max(tree.line) over (
                          partition by tree.owner, tree.object_type, tree.object_name
-                   ) + 1)
+                   ) + 1
+                )
           end as proc_ends_before_line,
           case
              when tree.is_new_proc = 'YES' then

--- a/database/utils/view/plscope_identifiers.sql
+++ b/database/utils/view/plscope_identifiers.sql
@@ -341,8 +341,8 @@ create or replace view plscope_identifiers as
             and tree.object_name = ids.object_name
             and tree.usage_id = ids.usage_context_id
       ),
-      tree_plus as (                                                    --@formatter:off
-         select tree.*,
+      tree_plus as (
+         select tree.*,                                                 -- @formatter:off
                 case
                    when tree.usage = 'SQL_ID' then
                       tree.type || ' statement (sql_id: ' || tree.name || ')'
@@ -350,27 +350,30 @@ create or replace view plscope_identifiers as
                       tree.type || ' statement'
                    else
                       tree.name || ' (' || lower(tree.type) || ' ' || lower(tree.usage) || ')'
-                end  as name_usage,
+                end as name_usage,                                      -- @formatter:on
                 case
                    when type in ('PROCEDURE', 'FUNCTION')
                       and usage = 'DEFINITION'
-                      and nvl( lag( procedure_signature,
-                                    case is_def_child_of_decl
-                                       when 'YES' then 
-                                          2
-                                       else
-                                          1
-                                    end
-                               ) over (
-                                  partition by tree.owner, tree.object_type, tree.object_name
-                                  order by usage_id asc
-                               ),
-                               '----' ) <> procedure_signature
+                      and nvl(
+                         lag(
+                            procedure_signature,
+                            case is_def_child_of_decl
+                               when 'YES' then
+                                  2
+                               else
+                                  1
+                            end
+                         ) over (
+                            partition by tree.owner, tree.object_type, tree.object_name
+                            order by usage_id asc
+                         ),
+                         '----'
+                      ) != procedure_signature
                    then
                       'YES'
-                end  as is_new_proc
-           from tree                                                       
-      )                                                                 --@formatter:on
+                end as is_new_proc
+           from tree
+      )
    select tree.owner,
           tree.object_type,
           tree.object_name,

--- a/database/utils/view/plscope_identifiers.sql
+++ b/database/utils/view/plscope_identifiers.sql
@@ -27,7 +27,6 @@ create or replace view plscope_identifiers as
           where owner like nvl(sys_context('PLSCOPE', 'OWNER'), user)
             and type like nvl(sys_context('PLSCOPE', 'OBJECT_TYPE'), '%')
             and name like nvl(sys_context('PLSCOPE', 'OBJECT_NAME'), '%')
-            and origin_con_id = sys_context('USERENV', 'CON_ID')
       ),
       pls_ids as (
          select owner,
@@ -46,7 +45,6 @@ create or replace view plscope_identifiers as
           where owner like nvl(sys_context('PLSCOPE', 'OWNER'), user)
             and object_type like nvl(sys_context('PLSCOPE', 'OBJECT_TYPE'), '%')
             and object_name like nvl(sys_context('PLSCOPE', 'OBJECT_NAME'), '%')
-            and origin_con_id = sys_context('USERENV', 'CON_ID')
       ),
       sql_ids as (
          select owner,
@@ -65,7 +63,6 @@ create or replace view plscope_identifiers as
           where owner like nvl(sys_context('PLSCOPE', 'OWNER'), user)
             and object_type like nvl(sys_context('PLSCOPE', 'OBJECT_TYPE'), '%')
             and object_name like nvl(sys_context('PLSCOPE', 'OBJECT_NAME'), '%')
-            and origin_con_id = sys_context('USERENV', 'CON_ID')
       ),
       fids as (
          select 'NO' as is_sql_stmt,
@@ -89,7 +86,6 @@ create or replace view plscope_identifiers as
             and sig.object_name = pls_ids.object_name
             and sig.usage = 'DECLARATION'
             and sig.signature = pls_ids.signature
-            and sig.origin_con_id = pls_ids.origin_con_id
          union all
          select 'YES' as is_sql_stmt,
                 owner,

--- a/database/utils/view/plscope_identifiers.sql
+++ b/database/utils/view/plscope_identifiers.sql
@@ -259,7 +259,12 @@ create or replace view plscope_identifiers as
                       and ids.usage in ('DEFINITION', 'DECLARATION')
                       and ids.usage_context_id = 1
                    then
-                      decode(ids.procedure_scope, 'PUBLIC', 'PUBLIC', 'PRIVATE')
+                      case ids.procedure_scope
+                         when 'PUBLIC' then
+                            'PUBLIC'
+                         else
+                            'PRIVATE'
+                      end
                 end as procedure_scope,
                 ids.name,
                 case
@@ -350,7 +355,12 @@ create or replace view plscope_identifiers as
                    when type in ('PROCEDURE', 'FUNCTION')
                       and usage = 'DEFINITION'
                       and nvl( lag( procedure_signature,
-                                    decode(is_def_child_of_decl, 'YES', 2, 'NO', 1)
+                                    case is_def_child_of_decl
+                                       when 'YES' then 
+                                          2
+                                       else
+                                          1
+                                    end
                                ) over (
                                   partition by tree.owner, tree.object_type, tree.object_name
                                   order by usage_id asc

--- a/formatter/trivadis_custom_format.arbori
+++ b/formatter/trivadis_custom_format.arbori
@@ -1958,11 +1958,6 @@ r3_commands:
         if (indent.indexOf("\n") == -1) {
             struct.putNewline(node.from, theLineSeparator);
             logger.fine(struct.getClass(), "r3_commands: add line break at " + node.from + ".");
-        } else {
-            // remove existing indentation; enforce conformity in these cases
-            var newIndent = getLeadingNewLines(node.from);
-            struct.putNewline(node.from, newIndent);
-            logger.fine(struct.getClass(), "r3_commands: remove indentation at " + node.from + ".");
         }
     }
 }
@@ -2811,6 +2806,7 @@ r2_common:
     | [node) 'RETURN' & [node^) subprg_spec
     | [node-1) 'RETURN' & [node^) stmt
     | [node) plsql_declarations & ([node^) with_clause | [node^) with_clause___0)
+    | [node) colmapped_query_name___0
 ;
 
 r2_flowcontrol_condition:
@@ -2947,6 +2943,7 @@ r2_decrement_left_margin:
                 | [node^) XML_attributes_clause
                 | [node^^) analytic_function
                 | [node^) external_parameter_list
+                | [node^) colmapped_query_name___0
             )
     | [node) 'XMLTABLE' & [node^) xmltable
     | [node) 'JSON_TABLE' & [node^) json_table


### PR DESCRIPTION
- based on pull request #38 (many thanks to @rvo-cs)
    - new features by @rvo-cs
         - column `name_usage`: shows the name indented by level plus the `type` and `usage` in parenthesis. For SQL statements the `sql_id` is shown in parenthesis.
         - column `is_fixed_context_id`: `YES` if it was fixed otherwise null.
         - column `procedure_signature`: signature of `procedure_name` otherwise null.
         - column `proc_ends_before_line`: ending line of procedure/function definition otherwise null.
         - column `proc_ends_before_col`: ending column of procedure/function definition otherwise null.
         - column `ref_line`: referenced line of `ref_owner`/`ref_object_type`/`ref_object_name` combination, null if referenced object is null.
         - column `ref_col`: referenced column of `ref_owner`/`ref_object_type`/`ref_object_name` combination, null if referenced object is null.
    - bug fixes by @rvo-cs: 
         - column `procedure_scope` does not consider forward declarations
         - fixes #34: ORA-01489: result of string concatenation is too long
    - changes of the original PR
         - reformatted code
         - small rewrites to conform to the Trivadis PL/SQL & SQL Coding Guidelines
         - remove filter on column `origin_con_id`, see [ee61a99](https://github.com/PhilippSalvisberg/plscope-utils/commit/ee61a99febe14ebda4fdb36bb36226e28a6a4fe5) 
- fix test case test_get_view_source (due to usage of lowercase keywords)
- updated Arbori program to format recursive query correctly 