### PR TITLE
Minor enhancement/fix to the installation script

### DIFF
--- a/database/install.sql
+++ b/database/install.sql
@@ -74,8 +74,12 @@ show errors
 show errors
 @./utils/view/plscope_tab_usage.sql
 show errors
+set verify off
+set define on
 @./utils/view/plscope_naming.sql
 show errors
+set define off
+set verify on
 
 prompt ====================================================================
 prompt Grants

--- a/database/install.sql
+++ b/database/install.sql
@@ -18,12 +18,20 @@ set define off
 set echo off
 set serveroutput on size 100000
 
+-- Handling of SQL exceptions: use the default behaviour of continuing
+-- no matter what, so the readout should be checked carefully in the end.
+whenever sqlerror continue none
+
 prompt ====================================================================
 prompt This script installs plscope-utils.
 prompt
 prompt Connect to the target user (schema) of your choice.
 prompt See utils/user/plscope.sql for required privileges.
 prompt ====================================================================
+
+@./install/scripts/schema_sanity_check
+-- Note: the above will change the whenever sqlerror directive, then reset
+-- it to continue none if successful.
 
 prompt ====================================================================
 prompt Disable PL/Scope for this session

--- a/database/install/scripts/schema_sanity_check.sql
+++ b/database/install/scripts/schema_sanity_check.sql
@@ -1,0 +1,45 @@
+/*
+* Copyright 2017 Philipp Salvisberg <philipp.salvisberg@trivadis.com>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+prompt
+prompt ====================================================================
+prompt Sanity check: this script will fail with ORA-01722 invalid number
+prompt if run as SYSDBA, or if the current schema is SYS or SYSTEM.
+prompt ====================================================================
+prompt
+
+-- Needed for the script to stop if any SQL exception is raised
+whenever sqlerror exit failure rollback
+
+set feedback 0
+
+select to_number('MUST_NOT_BE_SYSDBA') 
+  from dual
+ where sys_context('USERENV', 'ISDBA') = 'TRUE';
+
+select to_number('MUST_NOT_BE_SYS')
+  from dual
+ where sys_context('USERENV', 'CURRENT_SCHEMA') = 'SYS';
+ 
+select to_number('MUST_NOT_BE_SYSTEM')
+  from dual
+ where sys_context('USERENV', 'CURRENT_SCHEMA') = 'SYSTEM';
+
+set feedback on
+
+-- Revert to the default handling of SQL exceptions
+whenever sqlerror continue none
+

--- a/database/install_test.sql
+++ b/database/install_test.sql
@@ -21,12 +21,19 @@ set linesize 200
 set pagesize 100
 set serveroutput on size 1000000
 
+-- Handling of SQL exceptions: use the default behaviour of continuing.
+whenever sqlerror continue none
+
 PROMPT ====================================================================
 PROMPT This script installs test packages for plscope-utils.
 PROMPT Tests require an installed utPLSQL v3.
 PROMPT
 PROMPT Connect to the plscope user.
 PROMPT ====================================================================
+
+@./install/scripts/schema_sanity_check
+-- Note: the above will change the whenever sqlerror directive, then reset
+-- it to continue none if successful.
 
 PROMPT ====================================================================
 PROMPT Disable PL/Scope for this session

--- a/database/utils/view/plscope_naming.sql
+++ b/database/utils/view/plscope_naming.sql
@@ -13,38 +13,51 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+
+column view_comment noprint new_value view_comment
+
+set termout off
+set feedback off
+
+select '/* ' || regexp_replace(q'< #
+    * You may configure regular expressions for every name check.         #
+    * Here's an example for overriding every attribute used in this view  #
+    * to combine various naming conventions:                              #
+    *                                                                     #
+         begin                                                                        #
+            plscope_context.set_attr('GLOBAL_VARIABLE_REGEX',       '^(g|m)_.*');     #
+            plscope_context.set_attr('LOCAL_RECORD_VARIABLE_REGEX', '^(r|l|v)_.*');   #
+            plscope_context.set_attr('LOCAL_ARRAY_VARIABLE_REGEX',  '^(t|l|v)_.*');   #
+            plscope_context.set_attr('LOCAL_OBJECT_VARIABLE_REGEX', '^(o|l|v)_.*');   #
+            plscope_context.set_attr('LOCAL_VARIABLE_REGEX',        '(^(l|v|c)_.*)|(^[ij]$)');                #
+            plscope_context.set_attr('CURSOR_REGEX',                '^(c|l)_.*');                             #
+            plscope_context.set_attr('CURSOR_PARAMETER_REGEX',      '(^(p|in|out|io)_.*)|(.*_(in|out|io)$)'); #
+            plscope_context.set_attr('IN_PARAMETER_REGEX',          '(^(in|p)_.*)|(.*_in$)');                 #
+            plscope_context.set_attr('OUT_PARAMETER_REGEX',         '(^(out|p)_.*)|(.*_out$)');               #
+            plscope_context.set_attr('IN_OUT_PARAMETER_REGEX',      '(^(io|p)_.*)|(.*_io$)');                 #
+            plscope_context.set_attr('RECORD_REGEX',                '^(r|tp?)_.*');                           #
+            plscope_context.set_attr('ARRAY_REGEX',                 '(^tp?_.*)|(^.*_(type?|l(ist)?|tab(type)?|t(able)?|arr(ay)?|ct|nt|ht)$)'); #
+            plscope_context.set_attr('EXCEPTION_REGEX',             '(^ex?_.*)|(.*_exc(eption)?$)'); #
+            plscope_context.set_attr('CONSTANT_REGEX',              '^(co?|gc?|m|l|k)_.*');          #
+            plscope_context.set_attr('SUBTYPE_REGEX',               '(^tp?_.*$)|(.*_type?$)');       #
+         end;                                                                                        #
+    *                                    #
+    * To restore default-settings call:  #
+    *                                    #
+         begin                           #
+            plscope_context.remove_all;  #
+         end;                            #
+    *                                    #
+   >', '\s*#$', '', 1, 0, 'm') || ' */' as view_comment
+ from dual
+/
+
+set feedback on
+set termout on
+
 create or replace view plscope_naming as
    with
-      /* 
-      * You may configure regular expressions for every name check. 
-      * Here's an example for overriding every attribute used in this view
-      * to combine various naming conventions:
-      *
-           begin
-              plscope_context.set_attr('GLOBAL_VARIABLE_REGEX',       '^(g|m)_.*');
-              plscope_context.set_attr('LOCAL_RECORD_VARIABLE_REGEX', '^(r|l|v)_.*');
-              plscope_context.set_attr('LOCAL_ARRAY_VARIABLE_REGEX',  '^(t|l|v)_.*');
-              plscope_context.set_attr('LOCAL_OBJECT_VARIABLE_REGEX', '^(o|l|v)_.*');
-              plscope_context.set_attr('LOCAL_VARIABLE_REGEX',        '(^(l|v|c)_.*)|(^[ij]$)');
-              plscope_context.set_attr('CURSOR_REGEX',                '^(c|l)_.*');
-              plscope_context.set_attr('CURSOR_PARAMETER_REGEX',      '(^(p|in|out|io)_.*)|(.*_(in|out|io)$)');
-              plscope_context.set_attr('IN_PARAMETER_REGEX',          '(^(in|p)_.*)|(.*_in$)');
-              plscope_context.set_attr('OUT_PARAMETER_REGEX',         '(^(out|p)_.*)|(.*_out$)');
-              plscope_context.set_attr('IN_OUT_PARAMETER_REGEX',      '(^(io|p)_.*)|(.*_io$)');
-              plscope_context.set_attr('RECORD_REGEX',                '^(r|tp?)_.*');
-              plscope_context.set_attr('ARRAY_REGEX',                 '(^tp?_.*)|(^.*_(type?|l(ist)?|tab(type)?|t(able)?|arr(ay)?|ct|nt|ht)$)');
-              plscope_context.set_attr('EXCEPTION_REGEX',             '(^ex?_.*)|(.*_exc(eption)?$)');
-              plscope_context.set_attr('CONSTANT_REGEX',              '^(co?|gc?|m|l|k)_.*');
-              plscope_context.set_attr('SUBTYPE_REGEX',               '(^tp?_.*$)|(.*_type?$)');
-           end;
-      *
-      * To restore default-settings call: 
-      *
-           begin
-              plscope_context.remove_all;
-           end;
-      * 
-      */
+   &&view_comment
       src as (
          select /*+ materialize */
                 owner,
@@ -485,4 +498,9 @@ create or replace view plscope_naming as
           col,
           text
      from checked
-    where message is not null;
+    where message is not null
+/
+
+undefine view_comment
+column view_comment clear
+


### PR DESCRIPTION
Hi Philipp,

Here is a pull request for a small enhancement, and a small fix, to the installation script of the core database objects:

1. Minor fix: SQL\*Plus 18.5 (\*) would not parse the C-style comment embedded in the PLSCOPE_NAMING view create statement correctly, resulting in that view not being created.

    (\*) Tested under Windows 7; SQL\*Plus from the Instant Client 18.5 bundle for Windows x64.

    Of course the installation runs fine under SQLcl, and SQL Developer, and (most likely) other versions of SQL\*Plus; this may even be platform-specific. Nevertheless, if one version/platform is affected, more might be, so...

    The fix consists in using a SQL\*Plus substitution variable; it's not terribly elegant, but it does the trick without sacrificing readability too much (in my opinion) for those reading it directly from the source file.

2. Minor enhancement; have the `install.sql` script fail if started as SYSDBA, or if the current schema is SYS or SYSTEM (for completeness). Because the `utils/user/plscope.sql` script must be run as SYSDBA first, it's extremely easy to omit switching to the PLSCOPE account, and call the `install.sql` script while being still connected as SYSDBA. And being a single command away from a disaster, even a small one, is unpleasant. Whereas putting a safeguard in the installation script is not difficult.

     Note that, in order to have the script fail, the `whenever sqlerror` directive must be used. So far, that directive was not present in any of the installation scripts, so the installation would run with whatever setting was effective in the client. But now we need to change it, and therefore we have to explicitly decide how to use it throughout the entire installation procedure. If it was only for SQL\*Plus, or even SQLcl, we could take the more sophisticated approach of using the `STORE SET` command to save the current settings, change the `whenever sqlerror` directive, then restore it later as it was initially. Unfortunately, the `STORE SET` command has never been ported to SQL Developer, so if we use it the behaviour of the installation procedure will be different in SQL Developer as compared to SQL\*Plus or SQLcl, which doesn't look good at all. So we should keep things very simple, and just decide on what the `whenever sqlerror` directive should be during the installation.

     In this pull-request, I have set it to the default SQL\*Plus behaviour, `whenever sqlerror continue none` (except during the above-mentioned sanity check), but you might have a different opinion about that, of course.

Best regards,