### PR TITLE
Enh. the "Compile with PL/Scope..." action (+ 1 report about synonyms)

### DIFF
--- a/sqldev/src/main/resources/com/salvis/plscope/sqldev/action/compile_with_plscope.xml
+++ b/sqldev/src/main/resources/com/salvis/plscope/sqldev/action/compile_with_plscope.xml
@@ -17,7 +17,10 @@ Recompiling PL/SQL code (and/or synonyms) may have cascading side effects, e.g.:
 . discarding the state of packages, causing ORA-04068 exceptions
 Make sure you know what you are doing.
 
-Note that this action is purposely disabled for SYS, SYSTEM, and other Oracle-maintained accounts.]]>
+Note that this action is purposely disabled for SYS, SYSTEM, and other Oracle-maintained accounts.
+
+Tip: if the Log to DBMS_OUTPUT option is On, don't forget to make a database call from a SQL worksheet,
+e.g. exec null; after running this action in order to have SQL Developer read from the output buffer.]]>
         </help>
         <prompt required="true">                            <!-- index: 0 -->
             <label>Use DBA or ALL views?</label>
@@ -199,32 +202,59 @@ select 'Yes' as val
 ]]>
 			</value>
 		</prompt>
-		<prompt type="confirm">                             <!-- index: 6 -->
+		<prompt>                                            <!-- index: 6 -->
+			<label>Log to DBMS_OUTPUT?</label>
+            <default><![CDATA[STATIC:Off]]>
+			</default>
+			<value><![CDATA[STATIC:Off:On - Summary only:On - Failed statements:On - All details]]>
+			</value>
+		</prompt>
+		<prompt type="confirm">                             <!-- index: 7 -->
 			<label>Confirm actions for target schema: #"OBJECT_OWNER"# ?</label>
 		</prompt>
 		<sql>
 			<![CDATA[declare
-   e_is_not_udt         exception;
-   e_typ_has_table_deps exception;
-   e_lib_has_table_deps exception;
-   e_no_privs           exception;
-   e_success_with_error exception;
-   
-   pragma exception_init(e_is_not_udt, -22307);
-   pragma exception_init(e_typ_has_table_deps, -2311);
-   pragma exception_init(e_lib_has_table_deps, -4069);
-   pragma exception_init(e_no_privs, -1031);
-   pragma exception_init(e_success_with_error, -24344);
-   
+   /* Expected error codes */
+   co_oerrn_is_not_udt          constant pls_integer := -22307;
+   co_oerrn_typ_has_table_deps  constant pls_integer := -2311;
+   co_oerrn_lib_has_table_deps  constant pls_integer := -4069;
+   co_oerrn_no_privs            constant pls_integer := -1031;
+   co_oerrn_success_with_error  constant pls_integer := -24344;
+
+   subtype oerrn_type is pls_integer;
+   type t_oerrns_type is table of oerrn_type;  /* For lists of expected error codes */
+
+   type t_errcnt_map_type is table of pls_integer index by oerrn_type;
+   g_errcnt t_errcnt_map_type;   /* For counting successful/failed statements */
+
+   /* Levels of log verbosity */
+   co_log_level_off             constant pls_integer := 0;
+   co_log_level_summary         constant pls_integer := 1;
+   co_log_level_failed_stmt     constant pls_integer := 2;
+   co_log_level_everything      constant pls_integer := 3;
+
+   g_log_level pls_integer := co_log_level_off;  /* User-specified verbosity level */
+
+   co_log_ind_step constant pls_integer := 3;    /* Log indentation step */
+   g_log_ind_level pls_integer := 0;             /* Log indentation level */
+
    /* Forward decl. */
    procedure assert_not_oracle_maintained (in_schema_name in varchar2);
    procedure set_plscope_settings (in_identifiers in varchar2, in_statements in varchar2);
    procedure assert_schema_has_no_ccflags (in_schema_name in varchar2);
    procedure compile_public_synonyms (in_schema_name in varchar2);
    procedure compile_private_synonyms (in_schema_name in varchar2);
+   procedure recomp_session_settings (in_schema_name in varchar2);
    procedure recomp_reuse_settings (in_schema_name in varchar2, 
          in_identifiers in varchar2, in_statements in varchar2);
-   procedure recomp_session_settings (in_schema_name in varchar2);
+   procedure exec_dyn_stmt(in_stmt in varchar2, in_expected_errors in t_oerrns_type);
+   procedure log_init (in_level in pls_integer);
+   procedure log_start (in_step_name in varchar2);
+   procedure log_end (in_step_name in varchar2);
+   procedure log_summary (in_step_name in varchar2 default null);
+   procedure log (in_msg in varchar2, in_level in pls_integer default co_log_level_summary);
+   procedure log_stmt (in_sqlcode in pls_integer, in_stmt in varchar2,
+         in_status in varchar2 default null);
 
    /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
    /* Main procedure; all placeholder substitutions are done here. */
@@ -250,9 +280,25 @@ select 'Yes' as val
             '#3#',
             '^Yes.*reuse settings'
          ));
+         
+      /* Shall we send feedback to the dbms_output buffer? */
+      l_log_level pls_integer := case '#6#'
+                                    when 'Off' then
+                                       co_log_level_off
+                                    when 'On - Summary only' then
+                                       co_log_level_summary
+                                    when 'On - Failed statements' then
+                                       co_log_level_failed_stmt
+                                    when 'On - All details' then
+                                       co_log_level_everything
+                                 end;
    begin
       /* Sanity check: this action is not for Oracle-maintained accounts. */
       assert_not_oracle_maintained( q'#"OBJECT_OWNER"#' );
+
+      log_init(l_log_level);
+      log_start('Compile with PL/Scope');
+      log('Target schema: ' || dbms_assert.enquote_name(q'#"OBJECT_OWNER"#', false));
       
       /* Set the plscope_settings session parameter */
       set_plscope_settings ( in_identifiers => '#1#'
@@ -287,6 +333,8 @@ select 'Yes' as val
             recomp_session_settings( q'#"OBJECT_OWNER"#' );
          end if;
       end if;
+      
+      log_end('Compile with PL/Scope');
    end main;
 
    /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
@@ -295,7 +343,7 @@ select 'Yes' as val
 
    procedure assert_not_oracle_maintained (in_schema_name in varchar2)
    is
-      l_oracle_maintained varchar2(1);
+      l_oracle_maintained varchar2(1 char);
    begin
       <<check_username>>
       begin
@@ -349,18 +397,21 @@ select 'Yes' as val
 
    procedure set_plscope_settings (in_identifiers in varchar2, in_statements in varchar2)
    is
+      l_plscope_settings varchar2(50 char);
    begin
-      if dbms_db_version.version <= 11 or
-         dbms_db_version.version = 12 and dbms_db_version.release = 1
-      then
-         /* PL/Scope identifiers since 11.1 */
-         execute immediate 'alter session set plscope_settings=''IDENTIFIERS:'
-            || in_identifiers || '''';
-      else
-         /* PL/Scope statements since 12.2 */
-         execute immediate 'alter session set plscope_settings=''IDENTIFIERS:'
-            || in_identifiers || ', STATEMENTS:' || in_statements || '''';
-      end if;
+      l_plscope_settings := 
+         case
+            when dbms_db_version.version <= 11 
+               or dbms_db_version.version = 12 and dbms_db_version.release = 1
+            then
+               /* PL/Scope identifiers since 11.1 */
+               'IDENTIFIERS:' || in_identifiers
+            else
+               /* PL/Scope statements since 12.2 */
+               'IDENTIFIERS:' || in_identifiers || ', STATEMENTS:' || in_statements
+         end;
+      execute immediate 'alter session set plscope_settings = ''' || l_plscope_settings || '''';
+      log('plscope_settings set to ''' || l_plscope_settings || ''' in session');
    end set_plscope_settings;
    
    procedure assert_schema_has_no_ccflags (in_schema_name in varchar2)
@@ -388,6 +439,7 @@ select 'Yes' as val
    procedure compile_public_synonyms (in_schema_name in varchar2)
    is
    begin
+      log_start('Compile public synonyms');
       for r in (
          select synonym_name
            from sys.#0#_synonyms
@@ -395,22 +447,24 @@ select 'Yes' as val
             and table_owner = in_schema_name
       )
       loop
-         begin
-            execute immediate 'alter public synonym '
+         exec_dyn_stmt(
+            in_stmt => 'alter public synonym '
                || dbms_assert.enquote_name(r.synonym_name, false)
-               || ' compile';
-         exception
-            when e_no_privs then
-               /* ignore when user does not have create public synonym 
-                  and drop public synonym privileges */
-               null;
-         end;
+               || ' compile',
+            in_expected_errors => t_oerrns_type(
+               co_oerrn_no_privs  /* user does not have create public synonym 
+                                     and drop public synonym privileges */
+            )
+         );
       end loop;
+      log_summary;
+      log_end('Compile public synonyms');
    end compile_public_synonyms;
 
    procedure compile_private_synonyms (in_schema_name in varchar2)
    is
    begin
+      log_start('Compile private synonyms');
       for r in (
          select owner,
                 synonym_name
@@ -418,17 +472,26 @@ select 'Yes' as val
           where owner = in_schema_name
       )
       loop
-         execute immediate 'alter synonym '
-            || dbms_assert.enquote_name(r.owner, false)
-            || '.'
-            || dbms_assert.enquote_name(r.synonym_name, false)
-            || ' compile';
+         exec_dyn_stmt(
+            in_stmt => 'alter synonym '
+               || dbms_assert.enquote_name(r.owner, false)
+               || '.'
+               || dbms_assert.enquote_name(r.synonym_name, false)
+               || ' compile',
+            in_expected_errors => t_oerrns_type(
+               co_oerrn_no_privs  /* insufficient privileges */
+            )
+         );
       end loop;
+      log_summary;
+      log_end('Compile private synonyms');
    end compile_private_synonyms;
 
    procedure recomp_session_settings (in_schema_name in varchar2)
    is
    begin
+      log_start('Compile schema, using session settings');
+      
       /* Compile types */
       <<types>>
       for r in (
@@ -447,30 +510,24 @@ select 'Yes' as val
           order by priority
       )
       loop
-         <<compile_type>>
-         begin
-            if r.object_type = 'TYPE' then
-               execute immediate 'alter type '
+         exec_dyn_stmt(
+            in_stmt => 'alter type '
                   || dbms_assert.enquote_name(r.owner, false)
                   || '.'
                   || dbms_assert.enquote_name(r.object_name, false)
-                  || ' compile';
-            else
-               execute immediate 'alter type '
-                  || dbms_assert.enquote_name(r.owner, false)
-                  || '.'
-                  || dbms_assert.enquote_name(r.object_name, false)
-                  || ' compile body';
-            end if;
-         exception
-            when e_is_not_udt then
-               /* ignore errors for non user-defined types */
-               null;
-            when e_typ_has_table_deps or e_lib_has_table_deps then
-               /* ignore when type/library has table dependents */
-               null;
-         end compile_type;
+                  || ' compile'
+                  || case r.object_type
+                        when 'TYPE BODY' then
+                           ' body'
+                     end,
+            in_expected_errors => t_oerrns_type(
+               co_oerrn_is_not_udt,          /* non user-defined types */
+               co_oerrn_typ_has_table_deps,  /* type has table dependents */
+               co_oerrn_lib_has_table_deps   /* library has table dependents */
+            )
+         );
       end loop types;
+      log_summary('compilation of types');
 
       /* compile_schema handles procedures, functions, packages, views and triggers only */
       dbms_utility.compile_schema(
@@ -478,6 +535,9 @@ select 'Yes' as val
          compile_all    => true,
          reuse_settings => false
       );
+      log_summary('dbms_utility.compile_schema');
+
+      log_end('Compile schema, using session settings');
    end recomp_session_settings;
 
    procedure recomp_reuse_settings (
@@ -614,7 +674,6 @@ select 'Yes' as val
       type t_schem_objs_type is table of r_schem_obj_type index by pls_integer;
 
       l_schem_objs t_schem_objs_type;
-      l_stmt varchar2(32000 byte);
       
       function compile_settings(
          in_plsql_optimize_level  in number,
@@ -728,31 +787,28 @@ select 'Yes' as val
                null;
          end check_transl_and_status;
          if l_syn_status = 'INVALID' then
-            if in_syn_owner = 'PUBLIC' then
-               <<recomp_pubsyn>>
-               begin
-                  execute immediate 'alter public synonym '
-                     || dbms_assert.enquote_name(in_syn_name, false)
-                     || ' compile';
-               exception
-                  when e_no_privs then
-                     /* ignore when user does not have sufficient privilege */
-                     null;
-               end recomp_pubsyn;
-            else
-               <<recomp_priv_syn>>
-               begin
-                  execute immediate 'alter synonym '
-                     || dbms_assert.enquote_name(in_syn_owner, false)
-                     || '.'
-                     || dbms_assert.enquote_name(in_syn_name, false)
-                     || ' compile';
-               end recomp_priv_syn;
-            end if;
+            exec_dyn_stmt(
+               in_stmt => 'alter '
+                  || case
+                        when in_syn_owner = 'PUBLIC' then
+                           'public synonym '
+                        else
+                           'synonym '
+                           || dbms_assert.enquote_name(in_syn_owner, false) 
+                           || '.'
+                     end
+                  || dbms_assert.enquote_name(in_syn_name, false)
+                  || ' compile',
+               in_expected_errors => t_oerrns_type(
+                  co_oerrn_no_privs  /* insufficient privileges */
+               )
+            );
          end if;
       end process_synonym;
   
    begin
+      log_start('Compile schema (reuse settings)');
+
       open c_dep_ordered_schem_objs(in_schema_name);
       fetch c_dep_ordered_schem_objs bulk collect into l_schem_objs;
       close c_dep_ordered_schem_objs;
@@ -782,59 +838,197 @@ select 'Yes' as val
             end if;
 
             /* Other objects */
-            l_stmt := 'alter '
-               || case l_schem_objs(i).type 
-                     when 'TYPE BODY' then
-                        'type'
-                     when 'PACKAGE BODY' then
-                        'package'
-                     else
-                        lower(l_schem_objs(i).type)
-                  end
-               || ' '
-               || dbms_assert.enquote_name(l_schem_objs(i).owner, false)
-               || '.'
-               || dbms_assert.enquote_name(l_schem_objs(i).name, false)
-               || ' compile'
-               || case  
-                     when l_schem_objs(i).type in ('TYPE', 'PACKAGE') then
-                        ' specification'
-                     when l_schem_objs(i).type in ('TYPE BODY', 'PACKAGE BODY') then
-                        ' body'
-                  end
-               || case 
-                     when l_schem_objs(i).type not in ( 'VIEW',
-                        'MATERIALIZED VIEW', 'OPERATOR' ) 
-                     then
-                        compile_settings( 
-                           in_plsql_optimize_level  => l_schem_objs(i).plsql_optimize_level,
-                           in_plsql_code_type       => l_schem_objs(i).plsql_code_type,
-                           in_plsql_debug           => l_schem_objs(i).plsql_debug,
-                           in_plsql_warnings        => l_schem_objs(i).plsql_warnings,
-                           in_plsql_ccflags         => l_schem_objs(i).plsql_ccflags,
-                           in_nls_length_semantics  => l_schem_objs(i).nls_length_semantics,
-                           in_identifiers           => in_identifiers,
-                           in_statements            => in_statements
-                        )
-                  end;
-
-            <<exec_compile_stmt>>
-            begin
-               execute immediate l_stmt;
-            exception
-               when e_is_not_udt then
-                  /* ignore errors for non user-defined types */
-                  null;
-               when e_typ_has_table_deps or e_lib_has_table_deps then
-                  /* ignore when type/library has table dependents */
-                  null;
-               when e_success_with_error then
-                  /* ignore if the object has compilation errors */
-                  null;
-            end exec_compile_stmt;
+            exec_dyn_stmt(
+               in_stmt => 'alter '
+                  || case l_schem_objs(i).type 
+                        when 'TYPE BODY' then
+                           'type'
+                        when 'PACKAGE BODY' then
+                           'package'
+                        else
+                           lower(l_schem_objs(i).type)
+                     end
+                  || ' '
+                  || dbms_assert.enquote_name(l_schem_objs(i).owner, false)
+                  || '.'
+                  || dbms_assert.enquote_name(l_schem_objs(i).name, false)
+                  || ' compile'
+                  || case  
+                        when l_schem_objs(i).type in ('TYPE', 'PACKAGE') then
+                           ' specification'
+                        when l_schem_objs(i).type in ('TYPE BODY', 'PACKAGE BODY') then
+                           ' body'
+                     end
+                  || case 
+                        when l_schem_objs(i).type not in ( 'VIEW',
+                           'MATERIALIZED VIEW', 'OPERATOR' ) 
+                        then
+                           compile_settings( 
+                              in_plsql_optimize_level  => l_schem_objs(i).plsql_optimize_level,
+                              in_plsql_code_type       => l_schem_objs(i).plsql_code_type,
+                              in_plsql_debug           => l_schem_objs(i).plsql_debug,
+                              in_plsql_warnings        => l_schem_objs(i).plsql_warnings,
+                              in_plsql_ccflags         => l_schem_objs(i).plsql_ccflags,
+                              in_nls_length_semantics  => l_schem_objs(i).nls_length_semantics,
+                              in_identifiers           => in_identifiers,
+                              in_statements            => in_statements
+                           )
+                     end,
+               in_expected_errors => t_oerrns_type(
+                  co_oerrn_is_not_udt,          /* errors for non user-defined types */
+                  co_oerrn_typ_has_table_deps,  /* type has table dependents */
+                  co_oerrn_lib_has_table_deps,  /* library has table dependents */
+                  co_oerrn_success_with_error,  /* object has compilation errors */
+                  co_oerrn_no_privs             /* insufficient privileges */
+               )
+            );
          end loop process_schem_objs;
       end if;
+
+      log_summary;      
+      log_end('Compile schema (reuse settings)');
    end recomp_reuse_settings;
+
+   procedure exec_dyn_stmt(
+      in_stmt              in varchar2,
+      in_expected_errors   in t_oerrns_type
+   )
+   is
+      l_sqlcode pls_integer;
+   begin
+      begin
+         execute immediate in_stmt;
+         l_sqlcode := 0;
+      exception
+         when others then
+            l_sqlcode := sqlcode;
+            if not l_sqlcode member of in_expected_errors then
+               log_stmt(l_sqlcode, in_stmt, in_status => 'UNEXPECTED ERROR');
+               raise;
+            end if;
+      end;
+      log_stmt(l_sqlcode, in_stmt);
+   end exec_dyn_stmt;
+
+   procedure log_init (in_level in pls_integer)
+   is
+   begin
+      if in_level != co_log_level_off then
+         dbms_output.enable(null);
+         g_log_level := in_level;
+      end if;
+   end log_init;
+
+   procedure log_start (in_step_name in varchar2)
+   is
+   begin
+      log(in_step_name || ' -- start');
+      g_log_ind_level := g_log_ind_level + 1;
+   end log_start;
+
+   procedure log_end (in_step_name in varchar2)
+   is
+   begin
+      g_log_ind_level := greatest(0, g_log_ind_level - 1);
+      log(in_step_name || ' -- end');
+      if g_log_ind_level = 0 then
+         log(null);
+      end if;
+   end log_end;
+
+   procedure log (
+      in_msg   in varchar2, 
+      in_level in pls_integer default co_log_level_summary
+   )
+   is
+   begin
+      if g_log_level >= in_level then
+         if in_msg is not null then
+            dbms_output.put_line(rpad(' ', co_log_ind_step * g_log_ind_level, ' ') || in_msg);
+         else
+            dbms_output.new_line;
+         end if;
+      end if;
+   end log;
+
+   procedure log_stmt(
+      in_sqlcode  in pls_integer, 
+      in_stmt     in varchar2,
+      in_status   in varchar2 default null
+   )
+   is
+   begin
+      if g_errcnt.exists(in_sqlcode) then
+         g_errcnt(in_sqlcode) := g_errcnt(in_sqlcode) + 1;
+      else
+         g_errcnt(in_sqlcode) := 1;
+      end if;
+      if in_sqlcode = 0 then
+         log('SUCCESS: ' || in_stmt, co_log_level_everything);
+      elsif in_status is not null then
+         log(in_status || ' (ORA' || to_char(in_sqlcode, 'S00000') || '): ' || in_stmt);
+      else
+         log('FAILED (ORA' || to_char(in_sqlcode, 'S00000') || '): ' || in_stmt,
+            co_log_level_failed_stmt);
+      end if;
+   end log_stmt;
+
+   procedure log_summary (in_step_name in varchar2 default null)
+   is
+      l_oerrn oerrn_type;
+      l_cnt_stmt_total pls_integer := 0;
+      l_cnt_stmt_failed pls_integer := 0;
+   begin
+      if in_step_name is not null then
+         log('Step completed: ' || in_step_name);
+      end if;
+      l_oerrn := g_errcnt.first;
+      <<compute_totals>>
+      while l_oerrn is not null loop
+         l_cnt_stmt_total := l_cnt_stmt_total + g_errcnt(l_oerrn);
+         if l_oerrn != 0 then
+            l_cnt_stmt_failed := l_cnt_stmt_failed + g_errcnt(l_oerrn);
+         end if;
+         l_oerrn := g_errcnt.next(l_oerrn);
+      end loop compute_totals;
+      if l_cnt_stmt_total > 0 then
+         log('Count of statements: ' || to_char(l_cnt_stmt_total)
+            || case 
+                  when l_cnt_stmt_failed = 0 then
+                     ' (no failed statement)'
+                  else
+                     ' (' || to_char(l_cnt_stmt_total - l_cnt_stmt_failed) || ' success, '
+                     || to_char(l_cnt_stmt_failed) || ' error'
+                     || case when l_cnt_stmt_failed > 1 then 's' end || ')'
+               end);
+         if l_cnt_stmt_failed > 0 then
+            log('Exception' || case when l_cnt_stmt_failed > 1 then 's' end || ':');
+            l_oerrn := g_errcnt.first;
+            <<error_recap>>
+            while l_oerrn is not null loop
+               if l_oerrn != 0 then
+                  log('  . ORA' || to_char(l_oerrn, 'S00000')
+                     || case l_oerrn
+                           when co_oerrn_is_not_udt then
+                              ' (not a user-defined type)'
+                           when co_oerrn_typ_has_table_deps then
+                              ' (valid type has type or table dependents)'
+                           when co_oerrn_lib_has_table_deps then
+                              ' (library has table dependents)'
+                           when co_oerrn_no_privs then
+                              ' (insufficient privileges)'
+                           when co_oerrn_success_with_error then
+                              ' (success with compilation error)'
+                        end
+                     || ': ' || to_char(g_errcnt(l_oerrn))
+                  );
+               end if;
+               l_oerrn := g_errcnt.next(l_oerrn);
+            end loop error_recap;
+         end if;
+      end if;
+      g_errcnt.delete;
+   end log_summary;
 
 begin
    main;
@@ -860,7 +1054,10 @@ Recompiling PL/SQL code (and/or synonyms) may have cascading side effects, e.g.:
 . discarding the state of packages, causing ORA-04068 exceptions
 Make sure you know what you are doing.
 
-Note that this action is purposely disabled for SYS, SYSTEM, and other Oracle-maintained accounts.]]>
+Note that this action is purposely disabled for SYS, SYSTEM, and other Oracle-maintained accounts.
+
+Tip: if the Log to DBMS_OUTPUT option is On, don't forget to make a database call from a SQL worksheet,
+e.g. exec null; after running this action in order to have SQL Developer read from the output buffer.]]>
         </help>
         <prompt required="true">                            <!-- index: 0 -->
             <label>Use DBA or ALL views?</label>
@@ -1042,32 +1239,59 @@ select 'Yes' as val
 ]]>
 			</value>
 		</prompt>
-		<prompt type="confirm">                             <!-- index: 6 -->
+		<prompt>                                            <!-- index: 6 -->
+			<label>Log to DBMS_OUTPUT?</label>
+            <default><![CDATA[STATIC:Off]]>
+			</default>
+			<value><![CDATA[STATIC:Off:On - Summary only:On - Failed statements:On - All details]]>
+			</value>
+		</prompt>
+		<prompt type="confirm">                             <!-- index: 7 -->
 			<label>Confirm actions for target schema: #"OBJECT_OWNER"# ?</label>
 		</prompt>
 		<sql>
 			<![CDATA[declare
-   e_is_not_udt         exception;
-   e_typ_has_table_deps exception;
-   e_lib_has_table_deps exception;
-   e_no_privs           exception;
-   e_success_with_error exception;
-   
-   pragma exception_init(e_is_not_udt, -22307);
-   pragma exception_init(e_typ_has_table_deps, -2311);
-   pragma exception_init(e_lib_has_table_deps, -4069);
-   pragma exception_init(e_no_privs, -1031);
-   pragma exception_init(e_success_with_error, -24344);
-   
+   /* Expected error codes */
+   co_oerrn_is_not_udt          constant pls_integer := -22307;
+   co_oerrn_typ_has_table_deps  constant pls_integer := -2311;
+   co_oerrn_lib_has_table_deps  constant pls_integer := -4069;
+   co_oerrn_no_privs            constant pls_integer := -1031;
+   co_oerrn_success_with_error  constant pls_integer := -24344;
+
+   subtype oerrn_type is pls_integer;
+   type t_oerrns_type is table of oerrn_type;  /* For lists of expected error codes */
+
+   type t_errcnt_map_type is table of pls_integer index by oerrn_type;
+   g_errcnt t_errcnt_map_type;   /* For counting successful/failed statements */
+
+   /* Levels of log verbosity */
+   co_log_level_off             constant pls_integer := 0;
+   co_log_level_summary         constant pls_integer := 1;
+   co_log_level_failed_stmt     constant pls_integer := 2;
+   co_log_level_everything      constant pls_integer := 3;
+
+   g_log_level pls_integer := co_log_level_off;  /* User-specified verbosity level */
+
+   co_log_ind_step constant pls_integer := 3;    /* Log indentation step */
+   g_log_ind_level pls_integer := 0;             /* Log indentation level */
+
    /* Forward decl. */
    procedure assert_not_oracle_maintained (in_schema_name in varchar2);
    procedure set_plscope_settings (in_identifiers in varchar2, in_statements in varchar2);
    procedure assert_schema_has_no_ccflags (in_schema_name in varchar2);
    procedure compile_public_synonyms (in_schema_name in varchar2);
    procedure compile_private_synonyms (in_schema_name in varchar2);
+   procedure recomp_session_settings (in_schema_name in varchar2);
    procedure recomp_reuse_settings (in_schema_name in varchar2, 
          in_identifiers in varchar2, in_statements in varchar2);
-   procedure recomp_session_settings (in_schema_name in varchar2);
+   procedure exec_dyn_stmt(in_stmt in varchar2, in_expected_errors in t_oerrns_type);
+   procedure log_init (in_level in pls_integer);
+   procedure log_start (in_step_name in varchar2);
+   procedure log_end (in_step_name in varchar2);
+   procedure log_summary (in_step_name in varchar2 default null);
+   procedure log (in_msg in varchar2, in_level in pls_integer default co_log_level_summary);
+   procedure log_stmt (in_sqlcode in pls_integer, in_stmt in varchar2,
+         in_status in varchar2 default null);
 
    /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
    /* Main procedure; all placeholder substitutions are done here. */
@@ -1093,9 +1317,25 @@ select 'Yes' as val
             '#3#',
             '^Yes.*reuse settings'
          ));
+         
+      /* Shall we send feedback to the dbms_output buffer? */
+      l_log_level pls_integer := case '#6#'
+                                    when 'Off' then
+                                       co_log_level_off
+                                    when 'On - Summary only' then
+                                       co_log_level_summary
+                                    when 'On - Failed statements' then
+                                       co_log_level_failed_stmt
+                                    when 'On - All details' then
+                                       co_log_level_everything
+                                 end;
    begin
       /* Sanity check: this action is not for Oracle-maintained accounts. */
       assert_not_oracle_maintained( q'#"OBJECT_OWNER"#' );
+
+      log_init(l_log_level);
+      log_start('Compile with PL/Scope');
+      log('Target schema: ' || dbms_assert.enquote_name(q'#"OBJECT_OWNER"#', false));
       
       /* Set the plscope_settings session parameter */
       set_plscope_settings ( in_identifiers => '#1#'
@@ -1130,6 +1370,8 @@ select 'Yes' as val
             recomp_session_settings( q'#"OBJECT_OWNER"#' );
          end if;
       end if;
+      
+      log_end('Compile with PL/Scope');
    end main;
 
    /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
@@ -1138,7 +1380,7 @@ select 'Yes' as val
 
    procedure assert_not_oracle_maintained (in_schema_name in varchar2)
    is
-      l_oracle_maintained varchar2(1);
+      l_oracle_maintained varchar2(1 char);
    begin
       <<check_username>>
       begin
@@ -1192,18 +1434,21 @@ select 'Yes' as val
 
    procedure set_plscope_settings (in_identifiers in varchar2, in_statements in varchar2)
    is
+      l_plscope_settings varchar2(50 char);
    begin
-      if dbms_db_version.version <= 11 or
-         dbms_db_version.version = 12 and dbms_db_version.release = 1
-      then
-         /* PL/Scope identifiers since 11.1 */
-         execute immediate 'alter session set plscope_settings=''IDENTIFIERS:'
-            || in_identifiers || '''';
-      else
-         /* PL/Scope statements since 12.2 */
-         execute immediate 'alter session set plscope_settings=''IDENTIFIERS:'
-            || in_identifiers || ', STATEMENTS:' || in_statements || '''';
-      end if;
+      l_plscope_settings := 
+         case
+            when dbms_db_version.version <= 11 
+               or dbms_db_version.version = 12 and dbms_db_version.release = 1
+            then
+               /* PL/Scope identifiers since 11.1 */
+               'IDENTIFIERS:' || in_identifiers
+            else
+               /* PL/Scope statements since 12.2 */
+               'IDENTIFIERS:' || in_identifiers || ', STATEMENTS:' || in_statements
+         end;
+      execute immediate 'alter session set plscope_settings = ''' || l_plscope_settings || '''';
+      log('plscope_settings set to ''' || l_plscope_settings || ''' in session');
    end set_plscope_settings;
    
    procedure assert_schema_has_no_ccflags (in_schema_name in varchar2)
@@ -1231,6 +1476,7 @@ select 'Yes' as val
    procedure compile_public_synonyms (in_schema_name in varchar2)
    is
    begin
+      log_start('Compile public synonyms');
       for r in (
          select synonym_name
            from sys.#0#_synonyms
@@ -1238,22 +1484,24 @@ select 'Yes' as val
             and table_owner = in_schema_name
       )
       loop
-         begin
-            execute immediate 'alter public synonym '
+         exec_dyn_stmt(
+            in_stmt => 'alter public synonym '
                || dbms_assert.enquote_name(r.synonym_name, false)
-               || ' compile';
-         exception
-            when e_no_privs then
-               /* ignore when user does not have create public synonym 
-                  and drop public synonym privileges */
-               null;
-         end;
+               || ' compile',
+            in_expected_errors => t_oerrns_type(
+               co_oerrn_no_privs  /* user does not have create public synonym 
+                                     and drop public synonym privileges */
+            )
+         );
       end loop;
+      log_summary;
+      log_end('Compile public synonyms');
    end compile_public_synonyms;
 
    procedure compile_private_synonyms (in_schema_name in varchar2)
    is
    begin
+      log_start('Compile private synonyms');
       for r in (
          select owner,
                 synonym_name
@@ -1261,17 +1509,26 @@ select 'Yes' as val
           where owner = in_schema_name
       )
       loop
-         execute immediate 'alter synonym '
-            || dbms_assert.enquote_name(r.owner, false)
-            || '.'
-            || dbms_assert.enquote_name(r.synonym_name, false)
-            || ' compile';
+         exec_dyn_stmt(
+            in_stmt => 'alter synonym '
+               || dbms_assert.enquote_name(r.owner, false)
+               || '.'
+               || dbms_assert.enquote_name(r.synonym_name, false)
+               || ' compile',
+            in_expected_errors => t_oerrns_type(
+               co_oerrn_no_privs  /* insufficient privileges */
+            )
+         );
       end loop;
+      log_summary;
+      log_end('Compile private synonyms');
    end compile_private_synonyms;
 
    procedure recomp_session_settings (in_schema_name in varchar2)
    is
    begin
+      log_start('Compile schema, using session settings');
+      
       /* Compile types */
       <<types>>
       for r in (
@@ -1290,30 +1547,24 @@ select 'Yes' as val
           order by priority
       )
       loop
-         <<compile_type>>
-         begin
-            if r.object_type = 'TYPE' then
-               execute immediate 'alter type '
+         exec_dyn_stmt(
+            in_stmt => 'alter type '
                   || dbms_assert.enquote_name(r.owner, false)
                   || '.'
                   || dbms_assert.enquote_name(r.object_name, false)
-                  || ' compile';
-            else
-               execute immediate 'alter type '
-                  || dbms_assert.enquote_name(r.owner, false)
-                  || '.'
-                  || dbms_assert.enquote_name(r.object_name, false)
-                  || ' compile body';
-            end if;
-         exception
-            when e_is_not_udt then
-               /* ignore errors for non user-defined types */
-               null;
-            when e_typ_has_table_deps or e_lib_has_table_deps then
-               /* ignore when type/library has table dependents */
-               null;
-         end compile_type;
+                  || ' compile'
+                  || case r.object_type
+                        when 'TYPE BODY' then
+                           ' body'
+                     end,
+            in_expected_errors => t_oerrns_type(
+               co_oerrn_is_not_udt,          /* non user-defined types */
+               co_oerrn_typ_has_table_deps,  /* type has table dependents */
+               co_oerrn_lib_has_table_deps   /* library has table dependents */
+            )
+         );
       end loop types;
+      log_summary('compilation of types');
 
       /* compile_schema handles procedures, functions, packages, views and triggers only */
       dbms_utility.compile_schema(
@@ -1321,6 +1572,9 @@ select 'Yes' as val
          compile_all    => true,
          reuse_settings => false
       );
+      log_summary('dbms_utility.compile_schema');
+
+      log_end('Compile schema, using session settings');
    end recomp_session_settings;
 
    procedure recomp_reuse_settings (
@@ -1457,7 +1711,6 @@ select 'Yes' as val
       type t_schem_objs_type is table of r_schem_obj_type index by pls_integer;
 
       l_schem_objs t_schem_objs_type;
-      l_stmt varchar2(32000 byte);
       
       function compile_settings(
          in_plsql_optimize_level  in number,
@@ -1571,31 +1824,28 @@ select 'Yes' as val
                null;
          end check_transl_and_status;
          if l_syn_status = 'INVALID' then
-            if in_syn_owner = 'PUBLIC' then
-               <<recomp_pubsyn>>
-               begin
-                  execute immediate 'alter public synonym '
-                     || dbms_assert.enquote_name(in_syn_name, false)
-                     || ' compile';
-               exception
-                  when e_no_privs then
-                     /* ignore when user does not have sufficient privilege */
-                     null;
-               end recomp_pubsyn;
-            else
-               <<recomp_priv_syn>>
-               begin
-                  execute immediate 'alter synonym '
-                     || dbms_assert.enquote_name(in_syn_owner, false)
-                     || '.'
-                     || dbms_assert.enquote_name(in_syn_name, false)
-                     || ' compile';
-               end recomp_priv_syn;
-            end if;
+            exec_dyn_stmt(
+               in_stmt => 'alter '
+                  || case
+                        when in_syn_owner = 'PUBLIC' then
+                           'public synonym '
+                        else
+                           'synonym '
+                           || dbms_assert.enquote_name(in_syn_owner, false) 
+                           || '.'
+                     end
+                  || dbms_assert.enquote_name(in_syn_name, false)
+                  || ' compile',
+               in_expected_errors => t_oerrns_type(
+                  co_oerrn_no_privs  /* insufficient privileges */
+               )
+            );
          end if;
       end process_synonym;
   
    begin
+      log_start('Compile schema (reuse settings)');
+
       open c_dep_ordered_schem_objs(in_schema_name);
       fetch c_dep_ordered_schem_objs bulk collect into l_schem_objs;
       close c_dep_ordered_schem_objs;
@@ -1625,59 +1875,197 @@ select 'Yes' as val
             end if;
 
             /* Other objects */
-            l_stmt := 'alter '
-               || case l_schem_objs(i).type 
-                     when 'TYPE BODY' then
-                        'type'
-                     when 'PACKAGE BODY' then
-                        'package'
-                     else
-                        lower(l_schem_objs(i).type)
-                  end
-               || ' '
-               || dbms_assert.enquote_name(l_schem_objs(i).owner, false)
-               || '.'
-               || dbms_assert.enquote_name(l_schem_objs(i).name, false)
-               || ' compile'
-               || case  
-                     when l_schem_objs(i).type in ('TYPE', 'PACKAGE') then
-                        ' specification'
-                     when l_schem_objs(i).type in ('TYPE BODY', 'PACKAGE BODY') then
-                        ' body'
-                  end
-               || case 
-                     when l_schem_objs(i).type not in ( 'VIEW',
-                        'MATERIALIZED VIEW', 'OPERATOR' ) 
-                     then
-                        compile_settings( 
-                           in_plsql_optimize_level  => l_schem_objs(i).plsql_optimize_level,
-                           in_plsql_code_type       => l_schem_objs(i).plsql_code_type,
-                           in_plsql_debug           => l_schem_objs(i).plsql_debug,
-                           in_plsql_warnings        => l_schem_objs(i).plsql_warnings,
-                           in_plsql_ccflags         => l_schem_objs(i).plsql_ccflags,
-                           in_nls_length_semantics  => l_schem_objs(i).nls_length_semantics,
-                           in_identifiers           => in_identifiers,
-                           in_statements            => in_statements
-                        )
-                  end;
-
-            <<exec_compile_stmt>>
-            begin
-               execute immediate l_stmt;
-            exception
-               when e_is_not_udt then
-                  /* ignore errors for non user-defined types */
-                  null;
-               when e_typ_has_table_deps or e_lib_has_table_deps then
-                  /* ignore when type/library has table dependents */
-                  null;
-               when e_success_with_error then
-                  /* ignore if the object has compilation errors */
-                  null;
-            end exec_compile_stmt;
+            exec_dyn_stmt(
+               in_stmt => 'alter '
+                  || case l_schem_objs(i).type 
+                        when 'TYPE BODY' then
+                           'type'
+                        when 'PACKAGE BODY' then
+                           'package'
+                        else
+                           lower(l_schem_objs(i).type)
+                     end
+                  || ' '
+                  || dbms_assert.enquote_name(l_schem_objs(i).owner, false)
+                  || '.'
+                  || dbms_assert.enquote_name(l_schem_objs(i).name, false)
+                  || ' compile'
+                  || case  
+                        when l_schem_objs(i).type in ('TYPE', 'PACKAGE') then
+                           ' specification'
+                        when l_schem_objs(i).type in ('TYPE BODY', 'PACKAGE BODY') then
+                           ' body'
+                     end
+                  || case 
+                        when l_schem_objs(i).type not in ( 'VIEW',
+                           'MATERIALIZED VIEW', 'OPERATOR' ) 
+                        then
+                           compile_settings( 
+                              in_plsql_optimize_level  => l_schem_objs(i).plsql_optimize_level,
+                              in_plsql_code_type       => l_schem_objs(i).plsql_code_type,
+                              in_plsql_debug           => l_schem_objs(i).plsql_debug,
+                              in_plsql_warnings        => l_schem_objs(i).plsql_warnings,
+                              in_plsql_ccflags         => l_schem_objs(i).plsql_ccflags,
+                              in_nls_length_semantics  => l_schem_objs(i).nls_length_semantics,
+                              in_identifiers           => in_identifiers,
+                              in_statements            => in_statements
+                           )
+                     end,
+               in_expected_errors => t_oerrns_type(
+                  co_oerrn_is_not_udt,          /* errors for non user-defined types */
+                  co_oerrn_typ_has_table_deps,  /* type has table dependents */
+                  co_oerrn_lib_has_table_deps,  /* library has table dependents */
+                  co_oerrn_success_with_error,  /* object has compilation errors */
+                  co_oerrn_no_privs             /* insufficient privileges */
+               )
+            );
          end loop process_schem_objs;
       end if;
+
+      log_summary;      
+      log_end('Compile schema (reuse settings)');
    end recomp_reuse_settings;
+
+   procedure exec_dyn_stmt(
+      in_stmt              in varchar2,
+      in_expected_errors   in t_oerrns_type
+   )
+   is
+      l_sqlcode pls_integer;
+   begin
+      begin
+         execute immediate in_stmt;
+         l_sqlcode := 0;
+      exception
+         when others then
+            l_sqlcode := sqlcode;
+            if not l_sqlcode member of in_expected_errors then
+               log_stmt(l_sqlcode, in_stmt, in_status => 'UNEXPECTED ERROR');
+               raise;
+            end if;
+      end;
+      log_stmt(l_sqlcode, in_stmt);
+   end exec_dyn_stmt;
+
+   procedure log_init (in_level in pls_integer)
+   is
+   begin
+      if in_level != co_log_level_off then
+         dbms_output.enable(null);
+         g_log_level := in_level;
+      end if;
+   end log_init;
+
+   procedure log_start (in_step_name in varchar2)
+   is
+   begin
+      log(in_step_name || ' -- start');
+      g_log_ind_level := g_log_ind_level + 1;
+   end log_start;
+
+   procedure log_end (in_step_name in varchar2)
+   is
+   begin
+      g_log_ind_level := greatest(0, g_log_ind_level - 1);
+      log(in_step_name || ' -- end');
+      if g_log_ind_level = 0 then
+         log(null);
+      end if;
+   end log_end;
+
+   procedure log (
+      in_msg   in varchar2, 
+      in_level in pls_integer default co_log_level_summary
+   )
+   is
+   begin
+      if g_log_level >= in_level then
+         if in_msg is not null then
+            dbms_output.put_line(rpad(' ', co_log_ind_step * g_log_ind_level, ' ') || in_msg);
+         else
+            dbms_output.new_line;
+         end if;
+      end if;
+   end log;
+
+   procedure log_stmt(
+      in_sqlcode  in pls_integer, 
+      in_stmt     in varchar2,
+      in_status   in varchar2 default null
+   )
+   is
+   begin
+      if g_errcnt.exists(in_sqlcode) then
+         g_errcnt(in_sqlcode) := g_errcnt(in_sqlcode) + 1;
+      else
+         g_errcnt(in_sqlcode) := 1;
+      end if;
+      if in_sqlcode = 0 then
+         log('SUCCESS: ' || in_stmt, co_log_level_everything);
+      elsif in_status is not null then
+         log(in_status || ' (ORA' || to_char(in_sqlcode, 'S00000') || '): ' || in_stmt);
+      else
+         log('FAILED (ORA' || to_char(in_sqlcode, 'S00000') || '): ' || in_stmt,
+            co_log_level_failed_stmt);
+      end if;
+   end log_stmt;
+
+   procedure log_summary (in_step_name in varchar2 default null)
+   is
+      l_oerrn oerrn_type;
+      l_cnt_stmt_total pls_integer := 0;
+      l_cnt_stmt_failed pls_integer := 0;
+   begin
+      if in_step_name is not null then
+         log('Step completed: ' || in_step_name);
+      end if;
+      l_oerrn := g_errcnt.first;
+      <<compute_totals>>
+      while l_oerrn is not null loop
+         l_cnt_stmt_total := l_cnt_stmt_total + g_errcnt(l_oerrn);
+         if l_oerrn != 0 then
+            l_cnt_stmt_failed := l_cnt_stmt_failed + g_errcnt(l_oerrn);
+         end if;
+         l_oerrn := g_errcnt.next(l_oerrn);
+      end loop compute_totals;
+      if l_cnt_stmt_total > 0 then
+         log('Count of statements: ' || to_char(l_cnt_stmt_total)
+            || case 
+                  when l_cnt_stmt_failed = 0 then
+                     ' (no failed statement)'
+                  else
+                     ' (' || to_char(l_cnt_stmt_total - l_cnt_stmt_failed) || ' success, '
+                     || to_char(l_cnt_stmt_failed) || ' error'
+                     || case when l_cnt_stmt_failed > 1 then 's' end || ')'
+               end);
+         if l_cnt_stmt_failed > 0 then
+            log('Exception' || case when l_cnt_stmt_failed > 1 then 's' end || ':');
+            l_oerrn := g_errcnt.first;
+            <<error_recap>>
+            while l_oerrn is not null loop
+               if l_oerrn != 0 then
+                  log('  . ORA' || to_char(l_oerrn, 'S00000')
+                     || case l_oerrn
+                           when co_oerrn_is_not_udt then
+                              ' (not a user-defined type)'
+                           when co_oerrn_typ_has_table_deps then
+                              ' (valid type has type or table dependents)'
+                           when co_oerrn_lib_has_table_deps then
+                              ' (library has table dependents)'
+                           when co_oerrn_no_privs then
+                              ' (insufficient privileges)'
+                           when co_oerrn_success_with_error then
+                              ' (success with compilation error)'
+                        end
+                     || ': ' || to_char(g_errcnt(l_oerrn))
+                  );
+               end if;
+               l_oerrn := g_errcnt.next(l_oerrn);
+            end loop error_recap;
+         end if;
+      end if;
+      g_errcnt.delete;
+   end log_summary;
 
 begin
    main;

--- a/sqldev/src/main/resources/com/salvis/plscope/sqldev/action/compile_with_plscope.xml
+++ b/sqldev/src/main/resources/com/salvis/plscope/sqldev/action/compile_with_plscope.xml
@@ -7,10 +7,22 @@
 	<!-- first item based on title is considered independent of minversion/maxversion -->
 	<item connType="Oracle" type="CONNECTION" reload="true" minversion="11.1">
 		<title>Compile with PL/Scope...</title>
+        <help><![CDATA[This dialog enables to recompile objects in the target schema, with PL/Scope or without.
+
+Additionally, private synonyms in the schema, and/or public synonyms into it, may be recompiled (optional).
+
+BEWARE!
+Recompiling PL/SQL code (and/or synonyms) may have cascading side effects, e.g.:
+. invalidation of dependent objects, possibly in other schemas
+. discarding the state of packages, causing ORA-04068 exceptions
+Make sure you know what you are doing.
+
+Note that this action is purposely disabled for SYS, SYSTEM, and other Oracle-maintained accounts.]]>
+        </help>
         <prompt required="true">                            <!-- index: 0 -->
             <label>Use DBA or ALL views?</label>
             <default><![CDATA[select case
-          when count(*) = 4 then
+          when count(*) = 6 then
              'Dba'
           else
              'All'
@@ -20,7 +32,9 @@
    and view_name in ( 'DBA_OBJECTS',
                       'DBA_SYNONYMS',
                       'DBA_DEPENDENCIES',
-                      'DBA_PLSQL_OBJECT_SETTINGS' )
+                      'DBA_MVIEWS',
+                      'DBA_PLSQL_OBJECT_SETTINGS',
+                      'DBA_TYPES' )
 ]]>
             </default>
             <value><![CDATA[select vlist.val
@@ -29,7 +43,7 @@
          select 'All' as val, 1 as rn from dual
        ) vlist,
        ( select case
-                   when count(*) = 4 then
+                   when count(*) = 6 then
                       1
                    else
                       -1
@@ -39,7 +53,9 @@
             and view_name in ( 'DBA_OBJECTS',
                                'DBA_SYNONYMS',
                                'DBA_DEPENDENCIES',
-                               'DBA_PLSQL_OBJECT_SETTINGS' )
+                               'DBA_MVIEWS',
+                               'DBA_PLSQL_OBJECT_SETTINGS',
+                               'DBA_TYPES' )
        ) prio
  order by vlist.rn * prio.order_indic
 ]]>
@@ -56,43 +72,41 @@
 		<prompt reload="true:0" required="true">            <!-- index: 3 -->
 			<label>Compile Code?</label>
             <default><![CDATA[select case
-          when :0 is not null and count(*) > 1 then
+          when q'#"OBJECT_OWNER"#' in ( /* Oracle-maintained accounts */
+             'ANONYMOUS'    , 'APPQOSSYS'        , 'AUDSYS',
+             'CTXSYS'       , 'DBSFWUSER'        , 'DBSNMP',
+             'DVF'          , 'DVSYS'            , 'EXFSYS',
+             'GGSYS'        , 'GSMADMIN_INTERNAL', 'GSMCATUSER',
+             'GSMROOTUSER'  , 'GSMUSER'          , 'LBACSYS',
+             'MDSYS'        , 'MGMT_VIEW'        , 'OJVMSYS',
+             'OLAPSYS'      , 'ORDDATA'          , 'ORDPLUGINS',
+             'ORDSYS'       , 'OUTLN'            , 'OWBSYS',
+             'REMOTE_SCHEDULER_AGENT'            , 'SI_INFORMTN_SCHEMA',
+             'SYS'          , 'SYSBACKUP'        , 'SYSDG',
+             'SYSKM'        , 'SYSMAN'           , 'SYSRAC',
+             'SYSTEM'       , 'WK_TEST'          , 'WKPROXY',
+             'WKSYS'        , 'WMSYS'            , 'XDB'
+          )
+          then
              'No'
           else
-             'Yes'
-       end as default_value
-  from ( select plsql_optimize_level,
-                plsql_code_type,
-                plsql_debug,
-                plsql_warnings,
-                nls_length_semantics
-           from #0#_plsql_object_settings
-          where owner = q'#"OBJECT_OWNER"#'
-          group by plsql_optimize_level,
-                plsql_code_type,
-                plsql_debug,
-                plsql_warnings,
-                nls_length_semantics
-       )
+             'Yes, reuse settings'
+       end as val
+  from dual
+ where :0 is not null
 ]]>
 			</default>
-            <value><![CDATA[select vlist.val
-       || case
-             when vlist.val = 'Yes'
-                and prio.order_indic = -1
-             then
-                '  !!! WARNING: per-module settings will be lost !!!'
-          end as val
-  from ( select 'Yes' as val, 0 as rn from dual
+            <value><![CDATA[select val
+  from ( select 1 as pri,
+                'Yes, reuse settings' as val
+           from dual
           union all
-         select 'No'  as val, 1 as rn from dual
-       ) vlist,
-       ( select case
-                   when :0 is not null and count(*) > 1 then
-                      -1
-                   else
-                      1
-                end as order_indic
+         select 2 as pri,
+                'Yes, use session settings'
+                || case
+                      when :0 is not null and count(*) > 1 then
+                         '  !!! WARNING !!!'
+                   end as val
            from ( select plsql_optimize_level,
                          plsql_code_type,
                          plsql_debug,
@@ -106,118 +120,328 @@
                          plsql_warnings,
                          nls_length_semantics
                 )
-       ) prio
- order by vlist.rn * prio.order_indic
+          union all
+         select 3 as pri,
+                'No' as val
+           from dual
+       )
+ where q'#"OBJECT_OWNER"#' not in ( /* Oracle-maintained accounts */
+          'ANONYMOUS'    , 'APPQOSSYS'        , 'AUDSYS',
+          'CTXSYS'       , 'DBSFWUSER'        , 'DBSNMP',
+          'DVF'          , 'DVSYS'            , 'EXFSYS',
+          'GGSYS'        , 'GSMADMIN_INTERNAL', 'GSMCATUSER',
+          'GSMROOTUSER'  , 'GSMUSER'          , 'LBACSYS',
+          'MDSYS'        , 'MGMT_VIEW'        , 'OJVMSYS',
+          'OLAPSYS'      , 'ORDDATA'          , 'ORDPLUGINS',
+          'ORDSYS'       , 'OUTLN'            , 'OWBSYS',
+          'REMOTE_SCHEDULER_AGENT'            , 'SI_INFORMTN_SCHEMA',
+          'SYS'          , 'SYSBACKUP'        , 'SYSDG',
+          'SYSKM'        , 'SYSMAN'           , 'SYSRAC',
+          'SYSTEM'       , 'WK_TEST'          , 'WKPROXY',
+          'WKSYS'        , 'WMSYS'            , 'XDB'
+       )
+       or pri >= 3
+ order by pri asc
 ]]>
 			</value>
 		</prompt>
 		<prompt>                                            <!-- index: 4 -->
 			<label>Compile Public Synonyms?</label>
-			<value><![CDATA[STATIC:Yes:No]]>
+            <default><![CDATA[STATIC:No]]>
+			</default>
+			<value><![CDATA[select 'No' as val
+  from dual
+ union all
+select 'Yes' as val
+  from dual
+ where q'#"OBJECT_OWNER"#' not in ( /* Oracle-maintained accounts */
+          'ANONYMOUS'    , 'APPQOSSYS'        , 'AUDSYS',
+          'CTXSYS'       , 'DBSFWUSER'        , 'DBSNMP',
+          'DVF'          , 'DVSYS'            , 'EXFSYS',
+          'GGSYS'        , 'GSMADMIN_INTERNAL', 'GSMCATUSER',
+          'GSMROOTUSER'  , 'GSMUSER'          , 'LBACSYS',
+          'MDSYS'        , 'MGMT_VIEW'        , 'OJVMSYS',
+          'OLAPSYS'      , 'ORDDATA'          , 'ORDPLUGINS',
+          'ORDSYS'       , 'OUTLN'            , 'OWBSYS',
+          'REMOTE_SCHEDULER_AGENT'            , 'SI_INFORMTN_SCHEMA',
+          'SYS'          , 'SYSBACKUP'        , 'SYSDG',
+          'SYSKM'        , 'SYSMAN'           , 'SYSRAC',
+          'SYSTEM'       , 'WK_TEST'          , 'WKPROXY',
+          'WKSYS'        , 'WMSYS'            , 'XDB'
+       )
+]]>
 			</value>
 		</prompt>
 		<prompt>                                            <!-- index: 5 -->
 			<label>Compile Private Synonyms?</label>
-			<value><![CDATA[STATIC:Yes:No]]>
+            <default><![CDATA[STATIC:No]]>
+			</default>
+			<value><![CDATA[select 'No' as val
+  from dual
+ union all
+select 'Yes' as val
+  from dual
+ where q'#"OBJECT_OWNER"#' not in ( /* Oracle-maintained accounts */
+          'ANONYMOUS'    , 'APPQOSSYS'        , 'AUDSYS',
+          'CTXSYS'       , 'DBSFWUSER'        , 'DBSNMP',
+          'DVF'          , 'DVSYS'            , 'EXFSYS',
+          'GGSYS'        , 'GSMADMIN_INTERNAL', 'GSMCATUSER',
+          'GSMROOTUSER'  , 'GSMUSER'          , 'LBACSYS',
+          'MDSYS'        , 'MGMT_VIEW'        , 'OJVMSYS',
+          'OLAPSYS'      , 'ORDDATA'          , 'ORDPLUGINS',
+          'ORDSYS'       , 'OUTLN'            , 'OWBSYS',
+          'REMOTE_SCHEDULER_AGENT'            , 'SI_INFORMTN_SCHEMA',
+          'SYS'          , 'SYSBACKUP'        , 'SYSDG',
+          'SYSKM'        , 'SYSMAN'           , 'SYSRAC',
+          'SYSTEM'       , 'WK_TEST'          , 'WKPROXY',
+          'WKSYS'        , 'WMSYS'            , 'XDB'
+       )
+]]>
 			</value>
 		</prompt>
 		<prompt type="confirm">                             <!-- index: 6 -->
 			<label>Confirm actions for target schema: #"OBJECT_OWNER"# ?</label>
 		</prompt>
 		<sql>
-			<![CDATA[
-declare
-   e_is_not_udt     exception;
-   e_has_table_deps exception;
-   e_no_privs       exception;
+			<![CDATA[declare
+   e_is_not_udt         exception;
+   e_typ_has_table_deps exception;
+   e_lib_has_table_deps exception;
+   e_no_privs           exception;
+   e_success_with_error exception;
+   
    pragma exception_init(e_is_not_udt, -22307);
-   pragma exception_init(e_has_table_deps, -2311);
+   pragma exception_init(e_typ_has_table_deps, -2311);
+   pragma exception_init(e_lib_has_table_deps, -4069);
    pragma exception_init(e_no_privs, -1031);
-begin
-   if dbms_db_version.version <= 11 or
-      dbms_db_version.version = 12 and dbms_db_version.release = 1
-   then
-      /* PL/Scope identifiers since 11.1 */
-      execute immediate q'{ALTER SESSION SET plscope_settings='IDENTIFIERS:#1#'}';
-   else
-      /* PL/Scope statements since 12.2 */
-      execute immediate q'{ALTER SESSION SET plscope_settings='IDENTIFIERS:#1#, STATEMENTS:#2#'}';
-   end if;
+   pragma exception_init(e_success_with_error, -24344);
+   
+   /* Forward decl. */
+   procedure assert_not_oracle_maintained (in_schema_name in varchar2);
+   procedure set_plscope_settings (in_identifiers in varchar2, in_statements in varchar2);
+   procedure assert_schema_has_no_ccflags (in_schema_name in varchar2);
+   procedure compile_public_synonyms (in_schema_name in varchar2);
+   procedure compile_private_synonyms (in_schema_name in varchar2);
+   procedure recomp_reuse_settings (in_schema_name in varchar2, 
+         in_identifiers in varchar2, in_statements in varchar2);
+   procedure recomp_session_settings (in_schema_name in varchar2);
 
-   if 'Yes' = substr('#3#', 1, 3) then
-      /* Make sure that PLSQL_CCFLAGS is not used in the target schema */
-      <<schema_has_ccflags_check>>
-      declare
-         l_cnt number;
-      begin
-         select count(*) into l_cnt
-           from #0#_plsql_object_settings
-          where owner = q'#"OBJECT_OWNER"#'
-            and plsql_ccflags is not null;
+   /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+   /* Main procedure; all placeholder substitutions are done here. */
+   /* (But see below for the exception to this rule.)              */
+   /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 
-         if l_cnt > 0 then
-            /* Schemas using plsql_ccflags are not supported in this action. */
-            raise_application_error(-20000,
-               'Unsupported: PLSQL_CCFLAGS is used in the '
-               || dbms_assert.enquote_name(q'#"OBJECT_OWNER"#', false)
-               || ' schema');
-         end if;
-      end schema_has_ccflags_check;
-   end if;
+   procedure main
+   is
+      /* Shall we compile public synonyms? */
+      l_is_compile_pub_syn boolean := ('Yes' = '#4#');
 
-   /* Compile public synonyms */
-   if 'Yes' = '#4#' and not (dbms_db_version.version = 11 and dbms_db_version.version = 1) then
+      /* Shall we compile private synonyms? */
+      l_is_compile_priv_syn boolean := ('Yes' = '#5#');
+      
+      /* Shall we compile code? */
+      l_is_compile_code boolean := ('Yes' = substr(
+            '#3#', 
+            1, 3
+         ));
+         
+      /* And if so, shall we reuse settings, or apply session settings? */
+      l_is_reuse_settings boolean := (regexp_like(
+            '#3#',
+            '^Yes.*reuse settings'
+         ));
+   begin
+      /* Sanity check: this action is not for Oracle-maintained accounts. */
+      assert_not_oracle_maintained( q'#"OBJECT_OWNER"#' );
+      
+      /* Set the plscope_settings session parameter */
+      set_plscope_settings ( in_identifiers => '#1#'
+                           , in_statements  => '#2#' );
+      
+      /* 
+         If compiling PL/SQL code and using session settings, we must make sure that 
+         plsql_ccflags is not used in any object in the schema, and abandon if it is, 
+         in order to prevent from losing module-specific settings of that parameter.
+       */
+      if l_is_compile_code and not l_is_reuse_settings then
+         assert_schema_has_no_ccflags( q'#"OBJECT_OWNER"#' );
+      end if;
+
       /* Compilation of synonyms have been introduced with EBR in 11.2 */
-      <<public_synonyms>>
+      if not (dbms_db_version.version = 11 and dbms_db_version.version = 1) then
+         if l_is_compile_pub_syn then
+            compile_public_synonyms( q'#"OBJECT_OWNER"#' );
+         end if;
+         if l_is_compile_priv_syn then
+            compile_private_synonyms( q'#"OBJECT_OWNER"#' );
+         end if;
+      end if;
+   
+      /* Compile code */
+      if l_is_compile_code then
+         if l_is_reuse_settings then
+            recomp_reuse_settings( in_schema_name => q'#"OBJECT_OWNER"#'
+                                 , in_identifiers => '#1#'
+                                 , in_statements  => '#2#' );
+         else
+            recomp_session_settings( q'#"OBJECT_OWNER"#' );
+         end if;
+      end if;
+   end main;
+
+   /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+   /* Note: no text substitution after this line, except #0# ~> ALL|DBA in view names.  */
+   /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+
+   procedure assert_not_oracle_maintained (in_schema_name in varchar2)
+   is
+      l_oracle_maintained varchar2(1);
+   begin
+      <<check_username>>
+      begin
+         execute immediate
+            case
+               when dbms_db_version.version >= 12 then
+                  q'[select usr.oracle_maintained
+                       from sys.all_users usr
+                      where usr.username = :name]'
+               else
+                  /* 11g: static list of known Oracle-maintained accounts */
+                  q'[select case
+                               when usr.username in (
+                                  'ANONYMOUS'    , 'APPQOSSYS'        , 'AUDSYS',
+                                  'CTXSYS'       , 'DBSFWUSER'        , 'DBSNMP',
+                                  'DVF'          , 'DVSYS'            , 'EXFSYS',
+                                  'GGSYS'        , 'GSMADMIN_INTERNAL', 'GSMCATUSER',
+                                  'GSMROOTUSER'  , 'GSMUSER'          , 'LBACSYS',
+                                  'MDSYS'        , 'MGMT_VIEW'        , 'OJVMSYS',
+                                  'OLAPSYS'      , 'ORDDATA'          , 'ORDPLUGINS',
+                                  'ORDSYS'       , 'OUTLN'            , 'OWBSYS',
+                                  'REMOTE_SCHEDULER_AGENT'            , 'SI_INFORMTN_SCHEMA',
+                                  'SYS'          , 'SYSBACKUP'        , 'SYSDG',
+                                  'SYSKM'        , 'SYSMAN'           , 'SYSRAC',
+                                  'SYSTEM'       , 'WK_TEST'          , 'WKPROXY',
+                                  'WKSYS'        , 'WMSYS'            , 'XDB' )
+                              then
+                                 'Y'
+                              else
+                                 'N'
+                            end as oracle_maintained
+                       from sys.all_users usr
+                      where usr.username = :name]'
+            end
+            into l_oracle_maintained
+            using in_schema_name;
+      exception
+         when no_data_found then
+            null;
+      end check_username;
+      if l_oracle_maintained is null then
+         raise_application_error(-20000, 'User '
+            || dbms_assert.enquote_name(in_schema_name, false)
+            || ' not found');
+      elsif l_oracle_maintained = 'Y' then
+         raise_application_error(-20000, 'Unsupported: '
+            || dbms_assert.enquote_name(in_schema_name, false)
+            || ' is an Oracle-maintained account');
+      end if;
+   end assert_not_oracle_maintained;
+
+   procedure set_plscope_settings (in_identifiers in varchar2, in_statements in varchar2)
+   is
+   begin
+      if dbms_db_version.version <= 11 or
+         dbms_db_version.version = 12 and dbms_db_version.release = 1
+      then
+         /* PL/Scope identifiers since 11.1 */
+         execute immediate 'alter session set plscope_settings=''IDENTIFIERS:'
+            || in_identifiers || '''';
+      else
+         /* PL/Scope statements since 12.2 */
+         execute immediate 'alter session set plscope_settings=''IDENTIFIERS:'
+            || in_identifiers || ', STATEMENTS:' || in_statements || '''';
+      end if;
+   end set_plscope_settings;
+   
+   procedure assert_schema_has_no_ccflags (in_schema_name in varchar2)
+   is
+      l_cnt number;
+   begin
+      select count(*) into l_cnt
+        from sys.#0#_plsql_object_settings
+       where owner = in_schema_name
+         and plsql_ccflags is not null;
+
+      if l_cnt > 0 then
+         /* 
+            Schemas using plsql_ccflags are not supported if recompiling
+            with session parameters, otherwise module-specific settings 
+            of that parameter could be lost.
+          */
+         raise_application_error(-20000,
+                                 'Unsupported: PLSQL_CCFLAGS is used in the '
+            || dbms_assert.enquote_name(in_schema_name, false)
+            || ' schema');
+      end if;
+   end assert_schema_has_no_ccflags;
+
+   procedure compile_public_synonyms (in_schema_name in varchar2)
+   is
+   begin
       for r in (
          select synonym_name
            from sys.#0#_synonyms
           where owner = 'PUBLIC'
-            and table_owner = q'#"OBJECT_OWNER"#'
+            and table_owner = in_schema_name
       )
       loop
-         <<compile_public_synonym>>
          begin
-            execute immediate 'ALTER PUBLIC SYNONYM '
+            execute immediate 'alter public synonym '
                || dbms_assert.enquote_name(r.synonym_name, false)
-               || ' COMPILE';
+               || ' compile';
          exception
             when e_no_privs then
-               /* ignore when user does not have create public synonym and drop public synonym privileges */
+               /* ignore when user does not have create public synonym 
+                  and drop public synonym privileges */
                null;
-         end compile_public_synonym;
-      end loop public_synonyms;
-   end if;
+         end;
+      end loop;
+   end compile_public_synonyms;
 
-   /* Compile private synonyms */
-   if 'Yes' = '#5#' and not (dbms_db_version.version = 11 and dbms_db_version.version = 1) then
-      /* Compilation of synonyms have been introduced with EBR in 11.2 */
-      <<synonyms>>
+   procedure compile_private_synonyms (in_schema_name in varchar2)
+   is
+   begin
       for r in (
-         select owner, synonym_name
+         select owner,
+                synonym_name
            from sys.#0#_synonyms
-          where owner = q'#"OBJECT_OWNER"#'
+          where owner = in_schema_name
       )
       loop
-         execute immediate 'ALTER SYNONYM '
+         execute immediate 'alter synonym '
             || dbms_assert.enquote_name(r.owner, false)
-            || '.' || dbms_assert.enquote_name(r.synonym_name, false)
-            || ' COMPILE';
-      end loop synonyms;
-   end if;
+            || '.'
+            || dbms_assert.enquote_name(r.synonym_name, false)
+            || ' compile';
+      end loop;
+   end compile_private_synonyms;
 
-   /* Compile code */
-   if 'Yes' = substr('#3#', 1, 3) then
+   procedure recomp_session_settings (in_schema_name in varchar2)
+   is
+   begin
       /* Compile types */
       <<types>>
       for r in (
-         select o.owner, o.object_type, o.object_name, count(d.name) as priority
+         select o.owner, 
+                o.object_type, 
+                o.object_name, 
+                count(d.name) as priority
            from sys.#0#_objects o
-           left join #0#_dependencies d
+           left join sys.#0#_dependencies d
              on d.owner = o.owner
             and d.type = o.object_type
             and d.name = o.object_name
-          where o.owner = q'#"OBJECT_OWNER"#'
+          where o.owner = in_schema_name
             and o.object_type in ('TYPE', 'TYPE BODY')
           group by o.owner, o.object_type, o.object_name
           order by priority
@@ -226,33 +450,394 @@ begin
          <<compile_type>>
          begin
             if r.object_type = 'TYPE' then
-               execute immediate 'ALTER TYPE '
+               execute immediate 'alter type '
                   || dbms_assert.enquote_name(r.owner, false)
-                  || '.' || dbms_assert.enquote_name(r.object_name, false)
-                  || ' COMPILE';
+                  || '.'
+                  || dbms_assert.enquote_name(r.object_name, false)
+                  || ' compile';
             else
-               execute immediate 'ALTER TYPE '
+               execute immediate 'alter type '
                   || dbms_assert.enquote_name(r.owner, false)
-                  || '.' || dbms_assert.enquote_name(r.object_name, false)
-                  || ' COMPILE BODY';
+                  || '.'
+                  || dbms_assert.enquote_name(r.object_name, false)
+                  || ' compile body';
             end if;
          exception
             when e_is_not_udt then
                /* ignore errors for non user-defined types */
                null;
-            when e_has_table_deps then
-               /* ignore when type is used in tables */
+            when e_typ_has_table_deps or e_lib_has_table_deps then
+               /* ignore when type/library has table dependents */
                null;
          end compile_type;
       end loop types;
 
       /* compile_schema handles procedures, functions, packages, views and triggers only */
       dbms_utility.compile_schema(
-         schema         => q'#"OBJECT_OWNER"#',
+         schema         => in_schema_name,
          compile_all    => true,
          reuse_settings => false
       );
-   end if;
+   end recomp_session_settings;
+
+   procedure recomp_reuse_settings (
+      in_schema_name  in varchar2,
+      in_identifiers  in varchar2,
+      in_statements   in varchar2
+   )
+   is
+      cursor c_dep_ordered_schem_objs (p_schema_name in varchar2) is
+         with
+            target_objs as (
+               select o.owner,
+                      o.object_type,
+                      o.object_name
+                 from sys.#0#_objects o
+                where o.owner = p_schema_name
+                  and o.object_type in ( 'PROCEDURE'
+                                       , 'FUNCTION'
+                                       , 'PACKAGE'
+                                       , 'PACKAGE BODY'
+                                       , 'TRIGGER'
+                                       , 'TYPE' 
+                                       , 'TYPE BODY'
+                                       , 'LIBRARY'
+                                       , 'OPERATOR'
+                                       , 'VIEW'
+                                       , 'MATERIALIZED VIEW'
+                                       , 'SYNONYM' )
+                union all
+               select s.owner,
+                      'SYNONYM'        as object_type,
+                      s.synonym_name   as object_name
+                 from sys.#0#_synonyms s
+                where s.owner = 'PUBLIC'
+                  and s.table_owner = p_schema_name
+            ),
+            dep_chains(
+               owner,
+               type,
+               name,
+               dependent_owner,
+               dependent_type,
+               dependent_name,
+               dep_depth
+            ) as (
+               select o.owner,
+                      o.object_type,
+                      o.object_name,
+                      o.owner,
+                      o.object_type,
+                      o.object_name, 
+                      0
+                 from target_objs o
+                union all
+               select d.referenced_owner,
+                      d.referenced_type,
+                      d.referenced_name,
+                      d.owner,
+                      d.type,
+                      d.name,
+                      o.dep_depth + 1
+                 from dep_chains o,
+                      sys.#0#_dependencies d
+                where o.owner = d.owner
+                  and o.type = d.type
+                  and o.name = d.name
+            )
+            cycle 
+               owner,
+               type,
+               name,
+               dependent_owner,
+               dependent_type,
+               dependent_name
+            set is_cycle to 'Y' default 'N',
+            dep_ordered_objs as (
+               select o.owner,
+                      o.type,
+                      o.name,
+                      max(o.dep_depth) as dep_depth
+                 from dep_chains o
+                where (o.owner = p_schema_name
+                        and o.type in ( 'PROCEDURE'
+                                      , 'FUNCTION'
+                                      , 'PACKAGE'
+                                      , 'PACKAGE BODY'
+                                      , 'TRIGGER'
+                                      , 'TYPE' 
+                                      , 'TYPE BODY'
+                                      , 'LIBRARY'
+                                      , 'OPERATOR'
+                                      , 'VIEW'
+                                      , 'MATERIALIZED VIEW'
+                                      , 'SYNONYM' ) 
+                      )
+                      or (o.owner = 'PUBLIC'
+                           and o.type = 'SYNONYM')
+                group by o.owner,
+                      o.type,
+                      o.name
+            ),
+            dep_ordered_objs_excl_shadow as (
+               select obj.owner,
+                      obj.type,
+                      obj.name,
+                      obj.dep_depth
+                 from dep_ordered_objs obj,
+                      sys.#0#_types typ
+                where obj.owner = typ.owner (+)
+                  and obj.name = typ.type_name (+)
+                  and (obj.type not in ('TYPE', 'TYPE BODY')
+                        or typ.owner is not null /* exclude shadow types */ )
+            )
+         select obj.owner,
+                obj.type,
+                obj.name,
+                pls.plsql_optimize_level,
+                pls.plsql_code_type,
+                pls.plsql_debug,
+                pls.plsql_warnings,
+                pls.nls_length_semantics,
+                pls.plsql_ccflags,
+                pls.plscope_settings
+           from dep_ordered_objs_excl_shadow obj,
+                sys.#0#_plsql_object_settings pls
+          where pls.owner (+) = obj.owner
+            and pls.type (+) = obj.type
+            and pls.name (+) = obj.name
+          order by obj.dep_depth desc,
+                obj.type,
+                obj.name;
+   
+      subtype r_schem_obj_type is c_dep_ordered_schem_objs%rowtype;
+      type t_schem_objs_type is table of r_schem_obj_type index by pls_integer;
+
+      l_schem_objs t_schem_objs_type;
+      l_stmt varchar2(32000 byte);
+      
+      function compile_settings(
+         in_plsql_optimize_level  in number,
+         in_plsql_code_type       in varchar2,
+         in_plsql_debug           in varchar2,
+         in_plsql_warnings        in varchar2,
+         in_plsql_ccflags         in varchar2,
+         in_nls_length_semantics  in varchar2,
+         in_identifiers           in varchar2,
+         in_statements            in varchar2
+      )
+      return varchar2
+      is
+      begin
+         return case
+                   when in_plsql_optimize_level is not null then
+                      ' plsql_optimize_level=' || to_char(in_plsql_optimize_level)
+                end
+            || case
+                  when in_plsql_code_type is not null then
+                     ' plsql_code_type=' || in_plsql_code_type
+               end
+            || case
+                  when in_plsql_debug is not null then
+                     ' plsql_debug=' || in_plsql_debug
+               end
+            || case
+                  when in_plsql_warnings is not null then
+                     ' plsql_warnings=''' || in_plsql_warnings || ''''
+               end
+            || case
+                  when in_plsql_ccflags is not null then
+                     ' plsql_ccflags=''' || in_plsql_ccflags || ''''
+               end
+            || case
+                  when in_nls_length_semantics is not null then
+                     ' nls_length_semantics=' || in_nls_length_semantics
+               end
+            || ' plscope_settings=''' 
+            || case
+                  when dbms_db_version.version <= 11 
+                     or dbms_db_version.version = 12 and dbms_db_version.release = 1
+                  then
+                     /* PL/Scope identifiers since 11.1 */
+                     'IDENTIFIERS:' || in_identifiers
+                  else
+                     /* PL/Scope statements since 12.2 */
+                     'IDENTIFIERS:' || in_identifiers || ', STATEMENTS:' || in_statements
+               end
+            || '''';
+      end compile_settings;
+  
+      function is_valid_view(
+         in_schema_name  in varchar2,
+         in_view_name    in varchar2
+      ) 
+      return boolean
+      is
+         l_status sys.#0#_objects.status %type;
+      begin
+         select obj.status into l_status
+           from sys.#0#_objects obj
+          where obj.owner = in_schema_name
+            and obj.object_type = 'VIEW'
+            and obj.object_name = in_view_name;
+         return l_status = 'VALID';
+      end is_valid_view;
+      
+      function is_mv_compile_state_valid(
+         in_schema_name  in varchar2,
+         in_mview_name   in varchar2
+      ) 
+      return boolean
+      is
+         l_compile_state sys.#0#_mviews.compile_state %type;
+      begin
+         select mv.compile_state into l_compile_state
+           from sys.#0#_mviews mv
+          where mv.owner = in_schema_name
+            and mv.mview_name = in_mview_name;
+         return l_compile_state = 'VALID';
+      end is_mv_compile_state_valid;
+
+      /* Recompile the specified synonym if it's invalid and its translation is valid */
+      procedure process_synonym(
+         in_syn_owner  in varchar2,
+         in_syn_name   in varchar2
+      )
+      is
+         l_syn_status sys.#0#_objects.status %type;
+      begin
+         <<check_transl_and_status>>
+         begin
+            select obj.status into l_syn_status
+              from sys.#0#_objects obj
+             where obj.owner = in_syn_owner
+               and obj.object_type = 'SYNONYM'
+               and obj.object_name = in_syn_name 
+               and exists (select 1
+                             from sys.#0#_synonyms s,
+                                  sys.#0#_objects o
+                            where s.owner = in_syn_owner
+                              and s.synonym_name = in_syn_name
+                              and o.owner = s.table_owner
+                              and o.object_name = s.table_name
+                              and o.namespace = 1
+                              and o.subobject_name is null);
+         exception
+            when no_data_found then
+               /* likely cause: this synonym has no valid translation */
+               null;
+         end check_transl_and_status;
+         if l_syn_status = 'INVALID' then
+            if in_syn_owner = 'PUBLIC' then
+               <<recomp_pubsyn>>
+               begin
+                  execute immediate 'alter public synonym '
+                     || dbms_assert.enquote_name(in_syn_name, false)
+                     || ' compile';
+               exception
+                  when e_no_privs then
+                     /* ignore when user does not have sufficient privilege */
+                     null;
+               end recomp_pubsyn;
+            else
+               <<recomp_priv_syn>>
+               begin
+                  execute immediate 'alter synonym '
+                     || dbms_assert.enquote_name(in_syn_owner, false)
+                     || '.'
+                     || dbms_assert.enquote_name(in_syn_name, false)
+                     || ' compile';
+               end recomp_priv_syn;
+            end if;
+         end if;
+      end process_synonym;
+  
+   begin
+      open c_dep_ordered_schem_objs(in_schema_name);
+      fetch c_dep_ordered_schem_objs bulk collect into l_schem_objs;
+      close c_dep_ordered_schem_objs;
+      
+      if l_schem_objs.count > 0 then
+         <<process_schem_objs>>
+         for i in l_schem_objs.first .. l_schem_objs.last loop
+            /* 
+              Skip views that are not invalid, and materialized views which 
+              don't need to be compiled, in order to spare invalidations
+             */
+            if (l_schem_objs(i).type = 'VIEW'
+                  and is_valid_view(in_schema_name, l_schem_objs(i).name))
+               or (l_schem_objs(i).type = 'MATERIALIZED VIEW'
+                     and is_mv_compile_state_valid(in_schema_name, l_schem_objs(i).name))
+            then
+               continue process_schem_objs;
+            end if;
+
+            /* Synonyms are handled in their own procedure */
+            if l_schem_objs(i).type = 'SYNONYM' then
+               process_synonym(
+                  in_syn_owner => l_schem_objs(i).owner,
+                  in_syn_name  => l_schem_objs(i).name
+               );
+               continue process_schem_objs;
+            end if;
+
+            /* Other objects */
+            l_stmt := 'alter '
+               || case l_schem_objs(i).type 
+                     when 'TYPE BODY' then
+                        'type'
+                     when 'PACKAGE BODY' then
+                        'package'
+                     else
+                        lower(l_schem_objs(i).type)
+                  end
+               || ' '
+               || dbms_assert.enquote_name(l_schem_objs(i).owner, false)
+               || '.'
+               || dbms_assert.enquote_name(l_schem_objs(i).name, false)
+               || ' compile'
+               || case  
+                     when l_schem_objs(i).type in ('TYPE', 'PACKAGE') then
+                        ' specification'
+                     when l_schem_objs(i).type in ('TYPE BODY', 'PACKAGE BODY') then
+                        ' body'
+                  end
+               || case 
+                     when l_schem_objs(i).type not in ( 'VIEW',
+                        'MATERIALIZED VIEW', 'OPERATOR' ) 
+                     then
+                        compile_settings( 
+                           in_plsql_optimize_level  => l_schem_objs(i).plsql_optimize_level,
+                           in_plsql_code_type       => l_schem_objs(i).plsql_code_type,
+                           in_plsql_debug           => l_schem_objs(i).plsql_debug,
+                           in_plsql_warnings        => l_schem_objs(i).plsql_warnings,
+                           in_plsql_ccflags         => l_schem_objs(i).plsql_ccflags,
+                           in_nls_length_semantics  => l_schem_objs(i).nls_length_semantics,
+                           in_identifiers           => in_identifiers,
+                           in_statements            => in_statements
+                        )
+                  end;
+
+            <<exec_compile_stmt>>
+            begin
+               execute immediate l_stmt;
+            exception
+               when e_is_not_udt then
+                  /* ignore errors for non user-defined types */
+                  null;
+               when e_typ_has_table_deps or e_lib_has_table_deps then
+                  /* ignore when type/library has table dependents */
+                  null;
+               when e_success_with_error then
+                  /* ignore if the object has compilation errors */
+                  null;
+            end exec_compile_stmt;
+         end loop process_schem_objs;
+      end if;
+   end recomp_reuse_settings;
+
+begin
+   main;
 end;
 ]]>
 		</sql>
@@ -265,10 +850,22 @@ end;
 	<!-- Copy of the previous item. Changed type only. A menu cannot be assigned to multiple nodes. -->
 	<item connType="Oracle" type="plscope-utils-root" reload="true" minversion="11.1">
 		<title>Compile with PL/Scope...</title>
+        <help><![CDATA[This dialog enables to recompile objects in the target schema, with PL/Scope or without.
+
+Additionally, private synonyms in the schema, and/or public synonyms into it, may be recompiled (optional).
+
+BEWARE!
+Recompiling PL/SQL code (and/or synonyms) may have cascading side effects, e.g.:
+. invalidation of dependent objects, possibly in other schemas
+. discarding the state of packages, causing ORA-04068 exceptions
+Make sure you know what you are doing.
+
+Note that this action is purposely disabled for SYS, SYSTEM, and other Oracle-maintained accounts.]]>
+        </help>
         <prompt required="true">                            <!-- index: 0 -->
             <label>Use DBA or ALL views?</label>
             <default><![CDATA[select case
-          when count(*) = 4 then
+          when count(*) = 6 then
              'Dba'
           else
              'All'
@@ -278,7 +875,9 @@ end;
    and view_name in ( 'DBA_OBJECTS',
                       'DBA_SYNONYMS',
                       'DBA_DEPENDENCIES',
-                      'DBA_PLSQL_OBJECT_SETTINGS' )
+                      'DBA_MVIEWS',
+                      'DBA_PLSQL_OBJECT_SETTINGS',
+                      'DBA_TYPES' )
 ]]>
             </default>
             <value><![CDATA[select vlist.val
@@ -287,7 +886,7 @@ end;
          select 'All' as val, 1 as rn from dual
        ) vlist,
        ( select case
-                   when count(*) = 4 then
+                   when count(*) = 6 then
                       1
                    else
                       -1
@@ -297,7 +896,9 @@ end;
             and view_name in ( 'DBA_OBJECTS',
                                'DBA_SYNONYMS',
                                'DBA_DEPENDENCIES',
-                               'DBA_PLSQL_OBJECT_SETTINGS' )
+                               'DBA_MVIEWS',
+                               'DBA_PLSQL_OBJECT_SETTINGS',
+                               'DBA_TYPES' )
        ) prio
  order by vlist.rn * prio.order_indic
 ]]>
@@ -314,43 +915,41 @@ end;
 		<prompt reload="true:0" required="true">            <!-- index: 3 -->
 			<label>Compile Code?</label>
             <default><![CDATA[select case
-          when :0 is not null and count(*) > 1 then
+          when q'#"OBJECT_OWNER"#' in ( /* Oracle-maintained accounts */
+             'ANONYMOUS'    , 'APPQOSSYS'        , 'AUDSYS',
+             'CTXSYS'       , 'DBSFWUSER'        , 'DBSNMP',
+             'DVF'          , 'DVSYS'            , 'EXFSYS',
+             'GGSYS'        , 'GSMADMIN_INTERNAL', 'GSMCATUSER',
+             'GSMROOTUSER'  , 'GSMUSER'          , 'LBACSYS',
+             'MDSYS'        , 'MGMT_VIEW'        , 'OJVMSYS',
+             'OLAPSYS'      , 'ORDDATA'          , 'ORDPLUGINS',
+             'ORDSYS'       , 'OUTLN'            , 'OWBSYS',
+             'REMOTE_SCHEDULER_AGENT'            , 'SI_INFORMTN_SCHEMA',
+             'SYS'          , 'SYSBACKUP'        , 'SYSDG',
+             'SYSKM'        , 'SYSMAN'           , 'SYSRAC',
+             'SYSTEM'       , 'WK_TEST'          , 'WKPROXY',
+             'WKSYS'        , 'WMSYS'            , 'XDB'
+          )
+          then
              'No'
           else
-             'Yes'
-       end as default_value
-  from ( select plsql_optimize_level,
-                plsql_code_type,
-                plsql_debug,
-                plsql_warnings,
-                nls_length_semantics
-           from #0#_plsql_object_settings
-          where owner = q'#"OBJECT_OWNER"#'
-          group by plsql_optimize_level,
-                plsql_code_type,
-                plsql_debug,
-                plsql_warnings,
-                nls_length_semantics
-       )
+             'Yes, reuse settings'
+       end as val
+  from dual
+ where :0 is not null
 ]]>
 			</default>
-            <value><![CDATA[select vlist.val
-       || case
-             when vlist.val = 'Yes'
-                and prio.order_indic = -1
-             then
-                '  !!! WARNING: per-module settings will be lost !!!'
-          end as val
-  from ( select 'Yes' as val, 0 as rn from dual
+            <value><![CDATA[select val
+  from ( select 1 as pri,
+                'Yes, reuse settings' as val
+           from dual
           union all
-         select 'No'  as val, 1 as rn from dual
-       ) vlist,
-       ( select case
-                   when :0 is not null and count(*) > 1 then
-                      -1
-                   else
-                      1
-                end as order_indic
+         select 2 as pri,
+                'Yes, use session settings'
+                || case
+                      when :0 is not null and count(*) > 1 then
+                         '  !!! WARNING !!!'
+                   end as val
            from ( select plsql_optimize_level,
                          plsql_code_type,
                          plsql_debug,
@@ -364,118 +963,328 @@ end;
                          plsql_warnings,
                          nls_length_semantics
                 )
-       ) prio
- order by vlist.rn * prio.order_indic
+          union all
+         select 3 as pri,
+                'No' as val
+           from dual
+       )
+ where q'#"OBJECT_OWNER"#' not in ( /* Oracle-maintained accounts */
+          'ANONYMOUS'    , 'APPQOSSYS'        , 'AUDSYS',
+          'CTXSYS'       , 'DBSFWUSER'        , 'DBSNMP',
+          'DVF'          , 'DVSYS'            , 'EXFSYS',
+          'GGSYS'        , 'GSMADMIN_INTERNAL', 'GSMCATUSER',
+          'GSMROOTUSER'  , 'GSMUSER'          , 'LBACSYS',
+          'MDSYS'        , 'MGMT_VIEW'        , 'OJVMSYS',
+          'OLAPSYS'      , 'ORDDATA'          , 'ORDPLUGINS',
+          'ORDSYS'       , 'OUTLN'            , 'OWBSYS',
+          'REMOTE_SCHEDULER_AGENT'            , 'SI_INFORMTN_SCHEMA',
+          'SYS'          , 'SYSBACKUP'        , 'SYSDG',
+          'SYSKM'        , 'SYSMAN'           , 'SYSRAC',
+          'SYSTEM'       , 'WK_TEST'          , 'WKPROXY',
+          'WKSYS'        , 'WMSYS'            , 'XDB'
+       )
+       or pri >= 3
+ order by pri asc
 ]]>
 			</value>
 		</prompt>
 		<prompt>                                            <!-- index: 4 -->
 			<label>Compile Public Synonyms?</label>
-			<value><![CDATA[STATIC:Yes:No]]>
+            <default><![CDATA[STATIC:No]]>
+			</default>
+			<value><![CDATA[select 'No' as val
+  from dual
+ union all
+select 'Yes' as val
+  from dual
+ where q'#"OBJECT_OWNER"#' not in ( /* Oracle-maintained accounts */
+          'ANONYMOUS'    , 'APPQOSSYS'        , 'AUDSYS',
+          'CTXSYS'       , 'DBSFWUSER'        , 'DBSNMP',
+          'DVF'          , 'DVSYS'            , 'EXFSYS',
+          'GGSYS'        , 'GSMADMIN_INTERNAL', 'GSMCATUSER',
+          'GSMROOTUSER'  , 'GSMUSER'          , 'LBACSYS',
+          'MDSYS'        , 'MGMT_VIEW'        , 'OJVMSYS',
+          'OLAPSYS'      , 'ORDDATA'          , 'ORDPLUGINS',
+          'ORDSYS'       , 'OUTLN'            , 'OWBSYS',
+          'REMOTE_SCHEDULER_AGENT'            , 'SI_INFORMTN_SCHEMA',
+          'SYS'          , 'SYSBACKUP'        , 'SYSDG',
+          'SYSKM'        , 'SYSMAN'           , 'SYSRAC',
+          'SYSTEM'       , 'WK_TEST'          , 'WKPROXY',
+          'WKSYS'        , 'WMSYS'            , 'XDB'
+       )
+]]>
 			</value>
 		</prompt>
 		<prompt>                                            <!-- index: 5 -->
 			<label>Compile Private Synonyms?</label>
-			<value><![CDATA[STATIC:Yes:No]]>
+            <default><![CDATA[STATIC:No]]>
+			</default>
+			<value><![CDATA[select 'No' as val
+  from dual
+ union all
+select 'Yes' as val
+  from dual
+ where q'#"OBJECT_OWNER"#' not in ( /* Oracle-maintained accounts */
+          'ANONYMOUS'    , 'APPQOSSYS'        , 'AUDSYS',
+          'CTXSYS'       , 'DBSFWUSER'        , 'DBSNMP',
+          'DVF'          , 'DVSYS'            , 'EXFSYS',
+          'GGSYS'        , 'GSMADMIN_INTERNAL', 'GSMCATUSER',
+          'GSMROOTUSER'  , 'GSMUSER'          , 'LBACSYS',
+          'MDSYS'        , 'MGMT_VIEW'        , 'OJVMSYS',
+          'OLAPSYS'      , 'ORDDATA'          , 'ORDPLUGINS',
+          'ORDSYS'       , 'OUTLN'            , 'OWBSYS',
+          'REMOTE_SCHEDULER_AGENT'            , 'SI_INFORMTN_SCHEMA',
+          'SYS'          , 'SYSBACKUP'        , 'SYSDG',
+          'SYSKM'        , 'SYSMAN'           , 'SYSRAC',
+          'SYSTEM'       , 'WK_TEST'          , 'WKPROXY',
+          'WKSYS'        , 'WMSYS'            , 'XDB'
+       )
+]]>
 			</value>
 		</prompt>
 		<prompt type="confirm">                             <!-- index: 6 -->
 			<label>Confirm actions for target schema: #"OBJECT_OWNER"# ?</label>
 		</prompt>
 		<sql>
-			<![CDATA[
-declare
-   e_is_not_udt     exception;
-   e_has_table_deps exception;
-   e_no_privs       exception;
+			<![CDATA[declare
+   e_is_not_udt         exception;
+   e_typ_has_table_deps exception;
+   e_lib_has_table_deps exception;
+   e_no_privs           exception;
+   e_success_with_error exception;
+   
    pragma exception_init(e_is_not_udt, -22307);
-   pragma exception_init(e_has_table_deps, -2311);
+   pragma exception_init(e_typ_has_table_deps, -2311);
+   pragma exception_init(e_lib_has_table_deps, -4069);
    pragma exception_init(e_no_privs, -1031);
-begin
-   if dbms_db_version.version <= 11 or
-      dbms_db_version.version = 12 and dbms_db_version.release = 1
-   then
-      /* PL/Scope identifiers since 11.1 */
-      execute immediate q'{ALTER SESSION SET plscope_settings='IDENTIFIERS:#1#'}';
-   else
-      /* PL/Scope statements since 12.2 */
-      execute immediate q'{ALTER SESSION SET plscope_settings='IDENTIFIERS:#1#, STATEMENTS:#2#'}';
-   end if;
+   pragma exception_init(e_success_with_error, -24344);
+   
+   /* Forward decl. */
+   procedure assert_not_oracle_maintained (in_schema_name in varchar2);
+   procedure set_plscope_settings (in_identifiers in varchar2, in_statements in varchar2);
+   procedure assert_schema_has_no_ccflags (in_schema_name in varchar2);
+   procedure compile_public_synonyms (in_schema_name in varchar2);
+   procedure compile_private_synonyms (in_schema_name in varchar2);
+   procedure recomp_reuse_settings (in_schema_name in varchar2, 
+         in_identifiers in varchar2, in_statements in varchar2);
+   procedure recomp_session_settings (in_schema_name in varchar2);
 
-   if 'Yes' = substr('#3#', 1, 3) then
-      /* Make sure that PLSQL_CCFLAGS is not used in the target schema */
-      <<schema_has_ccflags_check>>
-      declare
-         l_cnt number;
-      begin
-         select count(*) into l_cnt
-           from #0#_plsql_object_settings
-          where owner = q'#"OBJECT_OWNER"#'
-            and plsql_ccflags is not null;
+   /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+   /* Main procedure; all placeholder substitutions are done here. */
+   /* (But see below for the exception to this rule.)              */
+   /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 
-         if l_cnt > 0 then
-            /* Schemas using plsql_ccflags are not supported in this action. */
-            raise_application_error(-20000,
-               'Unsupported: PLSQL_CCFLAGS is used in the '
-               || dbms_assert.enquote_name(q'#"OBJECT_OWNER"#', false)
-               || ' schema');
-         end if;
-      end schema_has_ccflags_check;
-   end if;
+   procedure main
+   is
+      /* Shall we compile public synonyms? */
+      l_is_compile_pub_syn boolean := ('Yes' = '#4#');
 
-   /* Compile public synonyms */
-   if 'Yes' = '#4#' and not (dbms_db_version.version = 11 and dbms_db_version.version = 1) then
+      /* Shall we compile private synonyms? */
+      l_is_compile_priv_syn boolean := ('Yes' = '#5#');
+      
+      /* Shall we compile code? */
+      l_is_compile_code boolean := ('Yes' = substr(
+            '#3#', 
+            1, 3
+         ));
+         
+      /* And if so, shall we reuse settings, or apply session settings? */
+      l_is_reuse_settings boolean := (regexp_like(
+            '#3#',
+            '^Yes.*reuse settings'
+         ));
+   begin
+      /* Sanity check: this action is not for Oracle-maintained accounts. */
+      assert_not_oracle_maintained( q'#"OBJECT_OWNER"#' );
+      
+      /* Set the plscope_settings session parameter */
+      set_plscope_settings ( in_identifiers => '#1#'
+                           , in_statements  => '#2#' );
+      
+      /* 
+         If compiling PL/SQL code and using session settings, we must make sure that 
+         plsql_ccflags is not used in any object in the schema, and abandon if it is, 
+         in order to prevent from losing module-specific settings of that parameter.
+       */
+      if l_is_compile_code and not l_is_reuse_settings then
+         assert_schema_has_no_ccflags( q'#"OBJECT_OWNER"#' );
+      end if;
+
       /* Compilation of synonyms have been introduced with EBR in 11.2 */
-      <<public_synonyms>>
+      if not (dbms_db_version.version = 11 and dbms_db_version.version = 1) then
+         if l_is_compile_pub_syn then
+            compile_public_synonyms( q'#"OBJECT_OWNER"#' );
+         end if;
+         if l_is_compile_priv_syn then
+            compile_private_synonyms( q'#"OBJECT_OWNER"#' );
+         end if;
+      end if;
+   
+      /* Compile code */
+      if l_is_compile_code then
+         if l_is_reuse_settings then
+            recomp_reuse_settings( in_schema_name => q'#"OBJECT_OWNER"#'
+                                 , in_identifiers => '#1#'
+                                 , in_statements  => '#2#' );
+         else
+            recomp_session_settings( q'#"OBJECT_OWNER"#' );
+         end if;
+      end if;
+   end main;
+
+   /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+   /* Note: no text substitution after this line, except #0# ~> ALL|DBA in view names.  */
+   /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+
+   procedure assert_not_oracle_maintained (in_schema_name in varchar2)
+   is
+      l_oracle_maintained varchar2(1);
+   begin
+      <<check_username>>
+      begin
+         execute immediate
+            case
+               when dbms_db_version.version >= 12 then
+                  q'[select usr.oracle_maintained
+                       from sys.all_users usr
+                      where usr.username = :name]'
+               else
+                  /* 11g: static list of known Oracle-maintained accounts */
+                  q'[select case
+                               when usr.username in (
+                                  'ANONYMOUS'    , 'APPQOSSYS'        , 'AUDSYS',
+                                  'CTXSYS'       , 'DBSFWUSER'        , 'DBSNMP',
+                                  'DVF'          , 'DVSYS'            , 'EXFSYS',
+                                  'GGSYS'        , 'GSMADMIN_INTERNAL', 'GSMCATUSER',
+                                  'GSMROOTUSER'  , 'GSMUSER'          , 'LBACSYS',
+                                  'MDSYS'        , 'MGMT_VIEW'        , 'OJVMSYS',
+                                  'OLAPSYS'      , 'ORDDATA'          , 'ORDPLUGINS',
+                                  'ORDSYS'       , 'OUTLN'            , 'OWBSYS',
+                                  'REMOTE_SCHEDULER_AGENT'            , 'SI_INFORMTN_SCHEMA',
+                                  'SYS'          , 'SYSBACKUP'        , 'SYSDG',
+                                  'SYSKM'        , 'SYSMAN'           , 'SYSRAC',
+                                  'SYSTEM'       , 'WK_TEST'          , 'WKPROXY',
+                                  'WKSYS'        , 'WMSYS'            , 'XDB' )
+                              then
+                                 'Y'
+                              else
+                                 'N'
+                            end as oracle_maintained
+                       from sys.all_users usr
+                      where usr.username = :name]'
+            end
+            into l_oracle_maintained
+            using in_schema_name;
+      exception
+         when no_data_found then
+            null;
+      end check_username;
+      if l_oracle_maintained is null then
+         raise_application_error(-20000, 'User '
+            || dbms_assert.enquote_name(in_schema_name, false)
+            || ' not found');
+      elsif l_oracle_maintained = 'Y' then
+         raise_application_error(-20000, 'Unsupported: '
+            || dbms_assert.enquote_name(in_schema_name, false)
+            || ' is an Oracle-maintained account');
+      end if;
+   end assert_not_oracle_maintained;
+
+   procedure set_plscope_settings (in_identifiers in varchar2, in_statements in varchar2)
+   is
+   begin
+      if dbms_db_version.version <= 11 or
+         dbms_db_version.version = 12 and dbms_db_version.release = 1
+      then
+         /* PL/Scope identifiers since 11.1 */
+         execute immediate 'alter session set plscope_settings=''IDENTIFIERS:'
+            || in_identifiers || '''';
+      else
+         /* PL/Scope statements since 12.2 */
+         execute immediate 'alter session set plscope_settings=''IDENTIFIERS:'
+            || in_identifiers || ', STATEMENTS:' || in_statements || '''';
+      end if;
+   end set_plscope_settings;
+   
+   procedure assert_schema_has_no_ccflags (in_schema_name in varchar2)
+   is
+      l_cnt number;
+   begin
+      select count(*) into l_cnt
+        from sys.#0#_plsql_object_settings
+       where owner = in_schema_name
+         and plsql_ccflags is not null;
+
+      if l_cnt > 0 then
+         /* 
+            Schemas using plsql_ccflags are not supported if recompiling
+            with session parameters, otherwise module-specific settings 
+            of that parameter could be lost.
+          */
+         raise_application_error(-20000,
+                                 'Unsupported: PLSQL_CCFLAGS is used in the '
+            || dbms_assert.enquote_name(in_schema_name, false)
+            || ' schema');
+      end if;
+   end assert_schema_has_no_ccflags;
+
+   procedure compile_public_synonyms (in_schema_name in varchar2)
+   is
+   begin
       for r in (
          select synonym_name
            from sys.#0#_synonyms
           where owner = 'PUBLIC'
-            and table_owner = q'#"OBJECT_OWNER"#'
+            and table_owner = in_schema_name
       )
       loop
-         <<compile_public_synonym>>
          begin
-            execute immediate 'ALTER PUBLIC SYNONYM '
+            execute immediate 'alter public synonym '
                || dbms_assert.enquote_name(r.synonym_name, false)
-               || ' COMPILE';
+               || ' compile';
          exception
             when e_no_privs then
-               /* ignore when user does not have create public synonym and drop public synonym privileges */
+               /* ignore when user does not have create public synonym 
+                  and drop public synonym privileges */
                null;
-         end compile_public_synonym;
-      end loop public_synonyms;
-   end if;
+         end;
+      end loop;
+   end compile_public_synonyms;
 
-   /* Compile private synonyms */
-   if 'Yes' = '#5#' and not (dbms_db_version.version = 11 and dbms_db_version.version = 1) then
-      /* Compilation of synonyms have been introduced with EBR in 11.2 */
-      <<synonyms>>
+   procedure compile_private_synonyms (in_schema_name in varchar2)
+   is
+   begin
       for r in (
-         select owner, synonym_name
+         select owner,
+                synonym_name
            from sys.#0#_synonyms
-          where owner = q'#"OBJECT_OWNER"#'
+          where owner = in_schema_name
       )
       loop
-         execute immediate 'ALTER SYNONYM '
+         execute immediate 'alter synonym '
             || dbms_assert.enquote_name(r.owner, false)
-            || '.' || dbms_assert.enquote_name(r.synonym_name, false)
-            || ' COMPILE';
-      end loop synonyms;
-   end if;
+            || '.'
+            || dbms_assert.enquote_name(r.synonym_name, false)
+            || ' compile';
+      end loop;
+   end compile_private_synonyms;
 
-   /* Compile code */
-   if 'Yes' = substr('#3#', 1, 3) then
+   procedure recomp_session_settings (in_schema_name in varchar2)
+   is
+   begin
       /* Compile types */
       <<types>>
       for r in (
-         select o.owner, o.object_type, o.object_name, count(d.name) as priority
+         select o.owner, 
+                o.object_type, 
+                o.object_name, 
+                count(d.name) as priority
            from sys.#0#_objects o
-           left join #0#_dependencies d
+           left join sys.#0#_dependencies d
              on d.owner = o.owner
             and d.type = o.object_type
             and d.name = o.object_name
-          where o.owner = q'#"OBJECT_OWNER"#'
+          where o.owner = in_schema_name
             and o.object_type in ('TYPE', 'TYPE BODY')
           group by o.owner, o.object_type, o.object_name
           order by priority
@@ -484,33 +1293,394 @@ begin
          <<compile_type>>
          begin
             if r.object_type = 'TYPE' then
-               execute immediate 'ALTER TYPE '
+               execute immediate 'alter type '
                   || dbms_assert.enquote_name(r.owner, false)
-                  || '.' || dbms_assert.enquote_name(r.object_name, false)
-                  || ' COMPILE';
+                  || '.'
+                  || dbms_assert.enquote_name(r.object_name, false)
+                  || ' compile';
             else
-               execute immediate 'ALTER TYPE '
+               execute immediate 'alter type '
                   || dbms_assert.enquote_name(r.owner, false)
-                  || '.' || dbms_assert.enquote_name(r.object_name, false)
-                  || ' COMPILE BODY';
+                  || '.'
+                  || dbms_assert.enquote_name(r.object_name, false)
+                  || ' compile body';
             end if;
          exception
             when e_is_not_udt then
                /* ignore errors for non user-defined types */
                null;
-            when e_has_table_deps then
-               /* ignore when type is used in tables */
+            when e_typ_has_table_deps or e_lib_has_table_deps then
+               /* ignore when type/library has table dependents */
                null;
          end compile_type;
       end loop types;
 
       /* compile_schema handles procedures, functions, packages, views and triggers only */
       dbms_utility.compile_schema(
-         schema         => q'#"OBJECT_OWNER"#',
+         schema         => in_schema_name,
          compile_all    => true,
          reuse_settings => false
       );
-   end if;
+   end recomp_session_settings;
+
+   procedure recomp_reuse_settings (
+      in_schema_name  in varchar2,
+      in_identifiers  in varchar2,
+      in_statements   in varchar2
+   )
+   is
+      cursor c_dep_ordered_schem_objs (p_schema_name in varchar2) is
+         with
+            target_objs as (
+               select o.owner,
+                      o.object_type,
+                      o.object_name
+                 from sys.#0#_objects o
+                where o.owner = p_schema_name
+                  and o.object_type in ( 'PROCEDURE'
+                                       , 'FUNCTION'
+                                       , 'PACKAGE'
+                                       , 'PACKAGE BODY'
+                                       , 'TRIGGER'
+                                       , 'TYPE' 
+                                       , 'TYPE BODY'
+                                       , 'LIBRARY'
+                                       , 'OPERATOR'
+                                       , 'VIEW'
+                                       , 'MATERIALIZED VIEW'
+                                       , 'SYNONYM' )
+                union all
+               select s.owner,
+                      'SYNONYM'        as object_type,
+                      s.synonym_name   as object_name
+                 from sys.#0#_synonyms s
+                where s.owner = 'PUBLIC'
+                  and s.table_owner = p_schema_name
+            ),
+            dep_chains(
+               owner,
+               type,
+               name,
+               dependent_owner,
+               dependent_type,
+               dependent_name,
+               dep_depth
+            ) as (
+               select o.owner,
+                      o.object_type,
+                      o.object_name,
+                      o.owner,
+                      o.object_type,
+                      o.object_name, 
+                      0
+                 from target_objs o
+                union all
+               select d.referenced_owner,
+                      d.referenced_type,
+                      d.referenced_name,
+                      d.owner,
+                      d.type,
+                      d.name,
+                      o.dep_depth + 1
+                 from dep_chains o,
+                      sys.#0#_dependencies d
+                where o.owner = d.owner
+                  and o.type = d.type
+                  and o.name = d.name
+            )
+            cycle 
+               owner,
+               type,
+               name,
+               dependent_owner,
+               dependent_type,
+               dependent_name
+            set is_cycle to 'Y' default 'N',
+            dep_ordered_objs as (
+               select o.owner,
+                      o.type,
+                      o.name,
+                      max(o.dep_depth) as dep_depth
+                 from dep_chains o
+                where (o.owner = p_schema_name
+                        and o.type in ( 'PROCEDURE'
+                                      , 'FUNCTION'
+                                      , 'PACKAGE'
+                                      , 'PACKAGE BODY'
+                                      , 'TRIGGER'
+                                      , 'TYPE' 
+                                      , 'TYPE BODY'
+                                      , 'LIBRARY'
+                                      , 'OPERATOR'
+                                      , 'VIEW'
+                                      , 'MATERIALIZED VIEW'
+                                      , 'SYNONYM' ) 
+                      )
+                      or (o.owner = 'PUBLIC'
+                           and o.type = 'SYNONYM')
+                group by o.owner,
+                      o.type,
+                      o.name
+            ),
+            dep_ordered_objs_excl_shadow as (
+               select obj.owner,
+                      obj.type,
+                      obj.name,
+                      obj.dep_depth
+                 from dep_ordered_objs obj,
+                      sys.#0#_types typ
+                where obj.owner = typ.owner (+)
+                  and obj.name = typ.type_name (+)
+                  and (obj.type not in ('TYPE', 'TYPE BODY')
+                        or typ.owner is not null /* exclude shadow types */ )
+            )
+         select obj.owner,
+                obj.type,
+                obj.name,
+                pls.plsql_optimize_level,
+                pls.plsql_code_type,
+                pls.plsql_debug,
+                pls.plsql_warnings,
+                pls.nls_length_semantics,
+                pls.plsql_ccflags,
+                pls.plscope_settings
+           from dep_ordered_objs_excl_shadow obj,
+                sys.#0#_plsql_object_settings pls
+          where pls.owner (+) = obj.owner
+            and pls.type (+) = obj.type
+            and pls.name (+) = obj.name
+          order by obj.dep_depth desc,
+                obj.type,
+                obj.name;
+   
+      subtype r_schem_obj_type is c_dep_ordered_schem_objs%rowtype;
+      type t_schem_objs_type is table of r_schem_obj_type index by pls_integer;
+
+      l_schem_objs t_schem_objs_type;
+      l_stmt varchar2(32000 byte);
+      
+      function compile_settings(
+         in_plsql_optimize_level  in number,
+         in_plsql_code_type       in varchar2,
+         in_plsql_debug           in varchar2,
+         in_plsql_warnings        in varchar2,
+         in_plsql_ccflags         in varchar2,
+         in_nls_length_semantics  in varchar2,
+         in_identifiers           in varchar2,
+         in_statements            in varchar2
+      )
+      return varchar2
+      is
+      begin
+         return case
+                   when in_plsql_optimize_level is not null then
+                      ' plsql_optimize_level=' || to_char(in_plsql_optimize_level)
+                end
+            || case
+                  when in_plsql_code_type is not null then
+                     ' plsql_code_type=' || in_plsql_code_type
+               end
+            || case
+                  when in_plsql_debug is not null then
+                     ' plsql_debug=' || in_plsql_debug
+               end
+            || case
+                  when in_plsql_warnings is not null then
+                     ' plsql_warnings=''' || in_plsql_warnings || ''''
+               end
+            || case
+                  when in_plsql_ccflags is not null then
+                     ' plsql_ccflags=''' || in_plsql_ccflags || ''''
+               end
+            || case
+                  when in_nls_length_semantics is not null then
+                     ' nls_length_semantics=' || in_nls_length_semantics
+               end
+            || ' plscope_settings=''' 
+            || case
+                  when dbms_db_version.version <= 11 
+                     or dbms_db_version.version = 12 and dbms_db_version.release = 1
+                  then
+                     /* PL/Scope identifiers since 11.1 */
+                     'IDENTIFIERS:' || in_identifiers
+                  else
+                     /* PL/Scope statements since 12.2 */
+                     'IDENTIFIERS:' || in_identifiers || ', STATEMENTS:' || in_statements
+               end
+            || '''';
+      end compile_settings;
+  
+      function is_valid_view(
+         in_schema_name  in varchar2,
+         in_view_name    in varchar2
+      ) 
+      return boolean
+      is
+         l_status sys.#0#_objects.status %type;
+      begin
+         select obj.status into l_status
+           from sys.#0#_objects obj
+          where obj.owner = in_schema_name
+            and obj.object_type = 'VIEW'
+            and obj.object_name = in_view_name;
+         return l_status = 'VALID';
+      end is_valid_view;
+      
+      function is_mv_compile_state_valid(
+         in_schema_name  in varchar2,
+         in_mview_name   in varchar2
+      ) 
+      return boolean
+      is
+         l_compile_state sys.#0#_mviews.compile_state %type;
+      begin
+         select mv.compile_state into l_compile_state
+           from sys.#0#_mviews mv
+          where mv.owner = in_schema_name
+            and mv.mview_name = in_mview_name;
+         return l_compile_state = 'VALID';
+      end is_mv_compile_state_valid;
+
+      /* Recompile the specified synonym if it's invalid and its translation is valid */
+      procedure process_synonym(
+         in_syn_owner  in varchar2,
+         in_syn_name   in varchar2
+      )
+      is
+         l_syn_status sys.#0#_objects.status %type;
+      begin
+         <<check_transl_and_status>>
+         begin
+            select obj.status into l_syn_status
+              from sys.#0#_objects obj
+             where obj.owner = in_syn_owner
+               and obj.object_type = 'SYNONYM'
+               and obj.object_name = in_syn_name 
+               and exists (select 1
+                             from sys.#0#_synonyms s,
+                                  sys.#0#_objects o
+                            where s.owner = in_syn_owner
+                              and s.synonym_name = in_syn_name
+                              and o.owner = s.table_owner
+                              and o.object_name = s.table_name
+                              and o.namespace = 1
+                              and o.subobject_name is null);
+         exception
+            when no_data_found then
+               /* likely cause: this synonym has no valid translation */
+               null;
+         end check_transl_and_status;
+         if l_syn_status = 'INVALID' then
+            if in_syn_owner = 'PUBLIC' then
+               <<recomp_pubsyn>>
+               begin
+                  execute immediate 'alter public synonym '
+                     || dbms_assert.enquote_name(in_syn_name, false)
+                     || ' compile';
+               exception
+                  when e_no_privs then
+                     /* ignore when user does not have sufficient privilege */
+                     null;
+               end recomp_pubsyn;
+            else
+               <<recomp_priv_syn>>
+               begin
+                  execute immediate 'alter synonym '
+                     || dbms_assert.enquote_name(in_syn_owner, false)
+                     || '.'
+                     || dbms_assert.enquote_name(in_syn_name, false)
+                     || ' compile';
+               end recomp_priv_syn;
+            end if;
+         end if;
+      end process_synonym;
+  
+   begin
+      open c_dep_ordered_schem_objs(in_schema_name);
+      fetch c_dep_ordered_schem_objs bulk collect into l_schem_objs;
+      close c_dep_ordered_schem_objs;
+      
+      if l_schem_objs.count > 0 then
+         <<process_schem_objs>>
+         for i in l_schem_objs.first .. l_schem_objs.last loop
+            /* 
+              Skip views that are not invalid, and materialized views which 
+              don't need to be compiled, in order to spare invalidations
+             */
+            if (l_schem_objs(i).type = 'VIEW'
+                  and is_valid_view(in_schema_name, l_schem_objs(i).name))
+               or (l_schem_objs(i).type = 'MATERIALIZED VIEW'
+                     and is_mv_compile_state_valid(in_schema_name, l_schem_objs(i).name))
+            then
+               continue process_schem_objs;
+            end if;
+
+            /* Synonyms are handled in their own procedure */
+            if l_schem_objs(i).type = 'SYNONYM' then
+               process_synonym(
+                  in_syn_owner => l_schem_objs(i).owner,
+                  in_syn_name  => l_schem_objs(i).name
+               );
+               continue process_schem_objs;
+            end if;
+
+            /* Other objects */
+            l_stmt := 'alter '
+               || case l_schem_objs(i).type 
+                     when 'TYPE BODY' then
+                        'type'
+                     when 'PACKAGE BODY' then
+                        'package'
+                     else
+                        lower(l_schem_objs(i).type)
+                  end
+               || ' '
+               || dbms_assert.enquote_name(l_schem_objs(i).owner, false)
+               || '.'
+               || dbms_assert.enquote_name(l_schem_objs(i).name, false)
+               || ' compile'
+               || case  
+                     when l_schem_objs(i).type in ('TYPE', 'PACKAGE') then
+                        ' specification'
+                     when l_schem_objs(i).type in ('TYPE BODY', 'PACKAGE BODY') then
+                        ' body'
+                  end
+               || case 
+                     when l_schem_objs(i).type not in ( 'VIEW',
+                        'MATERIALIZED VIEW', 'OPERATOR' ) 
+                     then
+                        compile_settings( 
+                           in_plsql_optimize_level  => l_schem_objs(i).plsql_optimize_level,
+                           in_plsql_code_type       => l_schem_objs(i).plsql_code_type,
+                           in_plsql_debug           => l_schem_objs(i).plsql_debug,
+                           in_plsql_warnings        => l_schem_objs(i).plsql_warnings,
+                           in_plsql_ccflags         => l_schem_objs(i).plsql_ccflags,
+                           in_nls_length_semantics  => l_schem_objs(i).nls_length_semantics,
+                           in_identifiers           => in_identifiers,
+                           in_statements            => in_statements
+                        )
+                  end;
+
+            <<exec_compile_stmt>>
+            begin
+               execute immediate l_stmt;
+            exception
+               when e_is_not_udt then
+                  /* ignore errors for non user-defined types */
+                  null;
+               when e_typ_has_table_deps or e_lib_has_table_deps then
+                  /* ignore when type/library has table dependents */
+                  null;
+               when e_success_with_error then
+                  /* ignore if the object has compilation errors */
+                  null;
+            end exec_compile_stmt;
+         end loop process_schem_objs;
+      end if;
+   end recomp_reuse_settings;
+
+begin
+   main;
 end;
 ]]>
 		</sql>

--- a/sqldev/src/main/resources/com/salvis/plscope/sqldev/action/compile_with_plscope.xml
+++ b/sqldev/src/main/resources/com/salvis/plscope/sqldev/action/compile_with_plscope.xml
@@ -7,38 +7,14 @@
 	<!-- first item based on title is considered independent of minversion/maxversion -->
 	<item connType="Oracle" type="CONNECTION" reload="true" minversion="11.1">
 		<title>Compile with PL/Scope...</title>
-		<prompt type="radio">                               <!-- index: 0 -->
-			<label>Identifiers</label>
-			<value><![CDATA[STATIC:ALL:NONE:PUBLIC:SQL:PLSQL]]></value>
-		</prompt>
-		<prompt type="radio">                               <!-- index: 1 -->
-			<label>Statements</label>
-			<value><![CDATA[STATIC:ALL:NONE]]></value>
-		</prompt>
-		<prompt>                                            <!-- index: 2 -->
-			<label>Compile Code?</label>
-			<value><![CDATA[STATIC:Yes:No]]>
-			</value>
-		</prompt>
-		<prompt>                                            <!-- index: 3 -->
-			<label>Compile Public Synonyms?</label>
-			<value><![CDATA[STATIC:Yes:No]]>
-			</value>
-		</prompt>
-		<prompt>                                            <!-- index: 4 -->
-			<label>Compile Private Synonyms?</label>
-			<value><![CDATA[STATIC:Yes:No]]>
-			</value>
-		</prompt>
-        <prompt type="radio">                               <!-- index: 5 -->
+        <prompt required="true">                            <!-- index: 0 -->
             <label>Use DBA or ALL views?</label>
-            <default><![CDATA[
-select case
+            <default><![CDATA[select case
           when count(*) = 4 then
              'Dba'
           else
              'All'
-       end as default_value
+          end as default_value
   from all_views
  where owner = 'SYS'
    and view_name in ( 'DBA_OBJECTS',
@@ -47,8 +23,104 @@ select case
                       'DBA_PLSQL_OBJECT_SETTINGS' )
 ]]>
             </default>
-			<value><![CDATA[STATIC:Dba:All]]></value>
+            <value><![CDATA[select vlist.val
+  from ( select 'Dba' as val, 0 as rn from dual
+         union all
+         select 'All' as val, 1 as rn from dual
+       ) vlist,
+       ( select case
+                   when count(*) = 4 then
+                      1
+                   else
+                      -1
+                end as order_indic
+           from all_views
+          where owner = 'SYS'
+            and view_name in ( 'DBA_OBJECTS',
+                               'DBA_SYNONYMS',
+                               'DBA_DEPENDENCIES',
+                               'DBA_PLSQL_OBJECT_SETTINGS' )
+       ) prio
+ order by vlist.rn * prio.order_indic
+]]>
+            </value>
         </prompt>
+		<prompt type="radio">                               <!-- index: 1 -->
+			<label>Identifiers</label>
+			<value><![CDATA[STATIC:ALL:NONE:PUBLIC:SQL:PLSQL]]></value>
+		</prompt>
+		<prompt type="radio">                               <!-- index: 2 -->
+			<label>Statements</label>
+			<value><![CDATA[STATIC:ALL:NONE]]></value>
+		</prompt>
+		<prompt reload="true:0" required="true">            <!-- index: 3 -->
+			<label>Compile Code?</label>
+            <default><![CDATA[select case
+          when :0 is not null and count(*) > 1 then
+             'No'
+          else
+             'Yes'
+       end as default_value
+  from ( select plsql_optimize_level,
+                plsql_code_type,
+                plsql_debug,
+                plsql_warnings,
+                nls_length_semantics
+           from #0#_plsql_object_settings
+          where owner = q'#"OBJECT_OWNER"#'
+          group by plsql_optimize_level,
+                plsql_code_type,
+                plsql_debug,
+                plsql_warnings,
+                nls_length_semantics
+       )
+]]>
+			</default>
+            <value><![CDATA[select vlist.val
+       || case
+             when vlist.val = 'Yes'
+                and prio.order_indic = -1
+             then
+                '  !!! WARNING: per-module settings will be lost !!!'
+          end as val
+  from ( select 'Yes' as val, 0 as rn from dual
+          union all
+         select 'No'  as val, 1 as rn from dual
+       ) vlist,
+       ( select case
+                   when :0 is not null and count(*) > 1 then
+                      -1
+                   else
+                      1
+                end as order_indic
+           from ( select plsql_optimize_level,
+                         plsql_code_type,
+                         plsql_debug,
+                         plsql_warnings,
+                         nls_length_semantics
+                    from #0#_plsql_object_settings
+                   where owner = q'#"OBJECT_OWNER"#'
+                   group by plsql_optimize_level,
+                         plsql_code_type,
+                         plsql_debug,
+                         plsql_warnings,
+                         nls_length_semantics
+                )
+       ) prio
+ order by vlist.rn * prio.order_indic
+]]>
+			</value>
+		</prompt>
+		<prompt>                                            <!-- index: 4 -->
+			<label>Compile Public Synonyms?</label>
+			<value><![CDATA[STATIC:Yes:No]]>
+			</value>
+		</prompt>
+		<prompt>                                            <!-- index: 5 -->
+			<label>Compile Private Synonyms?</label>
+			<value><![CDATA[STATIC:Yes:No]]>
+			</value>
+		</prompt>
 		<prompt type="confirm">                             <!-- index: 6 -->
 			<label>Confirm actions for target schema: #"OBJECT_OWNER"# ?</label>
 		</prompt>
@@ -66,20 +138,20 @@ begin
       dbms_db_version.version = 12 and dbms_db_version.release = 1
    then
       /* PL/Scope identifiers since 11.1 */
-      execute immediate q'{ALTER SESSION SET plscope_settings='IDENTIFIERS:#0#'}';
+      execute immediate q'{ALTER SESSION SET plscope_settings='IDENTIFIERS:#1#'}';
    else
       /* PL/Scope statements since 12.2 */
-      execute immediate q'{ALTER SESSION SET plscope_settings='IDENTIFIERS:#0#, STATEMENTS:#1#'}';
+      execute immediate q'{ALTER SESSION SET plscope_settings='IDENTIFIERS:#1#, STATEMENTS:#2#'}';
    end if;
 
-   if '#2#' = 'Yes' then
+   if 'Yes' = substr('#3#', 1, 3) then
       /* Make sure that PLSQL_CCFLAGS is not used in the target schema */
       <<schema_has_ccflags_check>>
       declare
          l_cnt number;
       begin
          select count(*) into l_cnt
-           from #5#_plsql_object_settings
+           from #0#_plsql_object_settings
           where owner = q'#"OBJECT_OWNER"#'
             and plsql_ccflags is not null;
 
@@ -94,12 +166,12 @@ begin
    end if;
 
    /* Compile public synonyms */
-   if not (dbms_db_version.version = 11 and dbms_db_version.version = 1) and '#3#' = 'Yes' then
+   if 'Yes' = '#4#' and not (dbms_db_version.version = 11 and dbms_db_version.version = 1) then
       /* Compilation of synonyms have been introduced with EBR in 11.2 */
       <<public_synonyms>>
       for r in (
          select synonym_name
-           from sys.#5#_synonyms
+           from sys.#0#_synonyms
           where owner = 'PUBLIC'
             and table_owner = q'#"OBJECT_OWNER"#'
       )
@@ -118,12 +190,12 @@ begin
    end if;
 
    /* Compile private synonyms */
-   if not (dbms_db_version.version = 11 and dbms_db_version.version = 1) and '#4#' = 'Yes' then
+   if 'Yes' = '#5#' and not (dbms_db_version.version = 11 and dbms_db_version.version = 1) then
       /* Compilation of synonyms have been introduced with EBR in 11.2 */
       <<synonyms>>
       for r in (
          select owner, synonym_name
-           from sys.#5#_synonyms
+           from sys.#0#_synonyms
           where owner = q'#"OBJECT_OWNER"#'
       )
       loop
@@ -135,13 +207,13 @@ begin
    end if;
 
    /* Compile code */
-   if '#2#' = 'Yes' then
+   if 'Yes' = substr('#3#', 1, 3) then
       /* Compile types */
       <<types>>
       for r in (
          select o.owner, o.object_type, o.object_name, count(d.name) as priority
-           from sys.#5#_objects o
-           left join #5#_dependencies d
+           from sys.#0#_objects o
+           left join #0#_dependencies d
              on d.owner = o.owner
             and d.type = o.object_type
             and d.name = o.object_name
@@ -193,38 +265,14 @@ end;
 	<!-- Copy of the previous item. Changed type only. A menu cannot be assigned to multiple nodes. -->
 	<item connType="Oracle" type="plscope-utils-root" reload="true" minversion="11.1">
 		<title>Compile with PL/Scope...</title>
-		<prompt type="radio">                               <!-- index: 0 -->
-			<label>Identifiers</label>
-			<value><![CDATA[STATIC:ALL:NONE:PUBLIC:SQL:PLSQL]]></value>
-		</prompt>
-		<prompt type="radio">                               <!-- index: 1 -->
-			<label>Statements</label>
-			<value><![CDATA[STATIC:ALL:NONE]]></value>
-		</prompt>
-		<prompt>                                            <!-- index: 2 -->
-			<label>Compile Code?</label>
-			<value><![CDATA[STATIC:Yes:No]]>
-			</value>
-		</prompt>
-		<prompt>                                            <!-- index: 3 -->
-			<label>Compile Public Synonyms?</label>
-			<value><![CDATA[STATIC:Yes:No]]>
-			</value>
-		</prompt>
-		<prompt>                                            <!-- index: 4 -->
-			<label>Compile Private Synonyms?</label>
-			<value><![CDATA[STATIC:Yes:No]]>
-			</value>
-		</prompt>
-        <prompt type="radio">                               <!-- index: 5 -->
+        <prompt required="true">                            <!-- index: 0 -->
             <label>Use DBA or ALL views?</label>
-            <default><![CDATA[
-select case
+            <default><![CDATA[select case
           when count(*) = 4 then
              'Dba'
           else
              'All'
-       end as default_value
+          end as default_value
   from all_views
  where owner = 'SYS'
    and view_name in ( 'DBA_OBJECTS',
@@ -233,8 +281,104 @@ select case
                       'DBA_PLSQL_OBJECT_SETTINGS' )
 ]]>
             </default>
-			<value><![CDATA[STATIC:Dba:All]]></value>
+            <value><![CDATA[select vlist.val
+  from ( select 'Dba' as val, 0 as rn from dual
+         union all
+         select 'All' as val, 1 as rn from dual
+       ) vlist,
+       ( select case
+                   when count(*) = 4 then
+                      1
+                   else
+                      -1
+                end as order_indic
+           from all_views
+          where owner = 'SYS'
+            and view_name in ( 'DBA_OBJECTS',
+                               'DBA_SYNONYMS',
+                               'DBA_DEPENDENCIES',
+                               'DBA_PLSQL_OBJECT_SETTINGS' )
+       ) prio
+ order by vlist.rn * prio.order_indic
+]]>
+            </value>
         </prompt>
+		<prompt type="radio">                               <!-- index: 1 -->
+			<label>Identifiers</label>
+			<value><![CDATA[STATIC:ALL:NONE:PUBLIC:SQL:PLSQL]]></value>
+		</prompt>
+		<prompt type="radio">                               <!-- index: 2 -->
+			<label>Statements</label>
+			<value><![CDATA[STATIC:ALL:NONE]]></value>
+		</prompt>
+		<prompt reload="true:0" required="true">            <!-- index: 3 -->
+			<label>Compile Code?</label>
+            <default><![CDATA[select case
+          when :0 is not null and count(*) > 1 then
+             'No'
+          else
+             'Yes'
+       end as default_value
+  from ( select plsql_optimize_level,
+                plsql_code_type,
+                plsql_debug,
+                plsql_warnings,
+                nls_length_semantics
+           from #0#_plsql_object_settings
+          where owner = q'#"OBJECT_OWNER"#'
+          group by plsql_optimize_level,
+                plsql_code_type,
+                plsql_debug,
+                plsql_warnings,
+                nls_length_semantics
+       )
+]]>
+			</default>
+            <value><![CDATA[select vlist.val
+       || case
+             when vlist.val = 'Yes'
+                and prio.order_indic = -1
+             then
+                '  !!! WARNING: per-module settings will be lost !!!'
+          end as val
+  from ( select 'Yes' as val, 0 as rn from dual
+          union all
+         select 'No'  as val, 1 as rn from dual
+       ) vlist,
+       ( select case
+                   when :0 is not null and count(*) > 1 then
+                      -1
+                   else
+                      1
+                end as order_indic
+           from ( select plsql_optimize_level,
+                         plsql_code_type,
+                         plsql_debug,
+                         plsql_warnings,
+                         nls_length_semantics
+                    from #0#_plsql_object_settings
+                   where owner = q'#"OBJECT_OWNER"#'
+                   group by plsql_optimize_level,
+                         plsql_code_type,
+                         plsql_debug,
+                         plsql_warnings,
+                         nls_length_semantics
+                )
+       ) prio
+ order by vlist.rn * prio.order_indic
+]]>
+			</value>
+		</prompt>
+		<prompt>                                            <!-- index: 4 -->
+			<label>Compile Public Synonyms?</label>
+			<value><![CDATA[STATIC:Yes:No]]>
+			</value>
+		</prompt>
+		<prompt>                                            <!-- index: 5 -->
+			<label>Compile Private Synonyms?</label>
+			<value><![CDATA[STATIC:Yes:No]]>
+			</value>
+		</prompt>
 		<prompt type="confirm">                             <!-- index: 6 -->
 			<label>Confirm actions for target schema: #"OBJECT_OWNER"# ?</label>
 		</prompt>
@@ -252,20 +396,20 @@ begin
       dbms_db_version.version = 12 and dbms_db_version.release = 1
    then
       /* PL/Scope identifiers since 11.1 */
-      execute immediate q'{ALTER SESSION SET plscope_settings='IDENTIFIERS:#0#'}';
+      execute immediate q'{ALTER SESSION SET plscope_settings='IDENTIFIERS:#1#'}';
    else
       /* PL/Scope statements since 12.2 */
-      execute immediate q'{ALTER SESSION SET plscope_settings='IDENTIFIERS:#0#, STATEMENTS:#1#'}';
+      execute immediate q'{ALTER SESSION SET plscope_settings='IDENTIFIERS:#1#, STATEMENTS:#2#'}';
    end if;
 
-   if '#2#' = 'Yes' then
+   if 'Yes' = substr('#3#', 1, 3) then
       /* Make sure that PLSQL_CCFLAGS is not used in the target schema */
       <<schema_has_ccflags_check>>
       declare
          l_cnt number;
       begin
          select count(*) into l_cnt
-           from #5#_plsql_object_settings
+           from #0#_plsql_object_settings
           where owner = q'#"OBJECT_OWNER"#'
             and plsql_ccflags is not null;
 
@@ -280,12 +424,12 @@ begin
    end if;
 
    /* Compile public synonyms */
-   if not (dbms_db_version.version = 11 and dbms_db_version.version = 1) and '#3#' = 'Yes' then
+   if 'Yes' = '#4#' and not (dbms_db_version.version = 11 and dbms_db_version.version = 1) then
       /* Compilation of synonyms have been introduced with EBR in 11.2 */
       <<public_synonyms>>
       for r in (
          select synonym_name
-           from sys.#5#_synonyms
+           from sys.#0#_synonyms
           where owner = 'PUBLIC'
             and table_owner = q'#"OBJECT_OWNER"#'
       )
@@ -304,12 +448,12 @@ begin
    end if;
 
    /* Compile private synonyms */
-   if not (dbms_db_version.version = 11 and dbms_db_version.version = 1) and '#4#' = 'Yes' then
+   if 'Yes' = '#5#' and not (dbms_db_version.version = 11 and dbms_db_version.version = 1) then
       /* Compilation of synonyms have been introduced with EBR in 11.2 */
       <<synonyms>>
       for r in (
          select owner, synonym_name
-           from sys.#5#_synonyms
+           from sys.#0#_synonyms
           where owner = q'#"OBJECT_OWNER"#'
       )
       loop
@@ -321,13 +465,13 @@ begin
    end if;
 
    /* Compile code */
-   if '#2#' = 'Yes' then
+   if 'Yes' = substr('#3#', 1, 3) then
       /* Compile types */
       <<types>>
       for r in (
          select o.owner, o.object_type, o.object_name, count(d.name) as priority
-           from sys.#5#_objects o
-           left join #5#_dependencies d
+           from sys.#0#_objects o
+           left join #0#_dependencies d
              on d.owner = o.owner
             and d.type = o.object_type
             and d.name = o.object_name

--- a/sqldev/src/main/resources/com/salvis/plscope/sqldev/action/compile_with_plscope.xml
+++ b/sqldev/src/main/resources/com/salvis/plscope/sqldev/action/compile_with_plscope.xml
@@ -7,23 +7,49 @@
 	<!-- first item based on title is considered independent of minversion/maxversion -->
 	<item connType="Oracle" type="CONNECTION" reload="true" minversion="11.1">
 		<title>Compile with PL/Scope...</title>
-		<prompt type="radio">
+		<prompt type="radio">                               <!-- index: 0 -->
 			<label>Identifiers</label>
 			<value><![CDATA[STATIC:ALL:NONE:PUBLIC:SQL:PLSQL]]></value>
 		</prompt>
-		<prompt type="radio">
+		<prompt type="radio">                               <!-- index: 1 -->
 			<label>Statements</label>
 			<value><![CDATA[STATIC:ALL:NONE]]></value>
 		</prompt>
-		<prompt>
+		<prompt>                                            <!-- index: 2 -->
 			<label>Compile Code?</label>
 			<value><![CDATA[STATIC:Yes:No]]>
 			</value>
 		</prompt>
-		<prompt>
-			<label>Compile Synonyms?</label>
+		<prompt>                                            <!-- index: 3 -->
+			<label>Compile Public Synonyms?</label>
 			<value><![CDATA[STATIC:Yes:No]]>
 			</value>
+		</prompt>
+		<prompt>                                            <!-- index: 4 -->
+			<label>Compile Private Synonyms?</label>
+			<value><![CDATA[STATIC:Yes:No]]>
+			</value>
+		</prompt>
+        <prompt type="radio">                               <!-- index: 5 -->
+            <label>Use DBA or ALL views?</label>
+            <default><![CDATA[
+select case
+          when count(*) = 3 then
+             'Dba'
+          else
+             'All'
+       end as default_value
+  from all_views
+ where owner = 'SYS'
+   and view_name in ( 'DBA_OBJECTS',
+                      'DBA_SYNONYMS',
+                      'DBA_DEPENDENCIES' )
+]]>
+            </default>
+			<value><![CDATA[STATIC:Dba:All]]></value>
+        </prompt>
+		<prompt type="confirm">                             <!-- index: 6 -->
+			<label>Confirm actions for target schema: #"OBJECT_OWNER"# ?</label>
 		</prompt>
 		<sql>
 			<![CDATA[
@@ -39,37 +65,28 @@ begin
       dbms_db_version.version = 12 and dbms_db_version.release = 1
    then
       /* PL/Scope identifiers since 11.1 */
-      execute immediate q'[ALTER SESSION SET plscope_settings='IDENTIFIERS:#0#']';
+      execute immediate q'{ALTER SESSION SET plscope_settings='IDENTIFIERS:#0#'}';
    else
       /* PL/Scope statements since 12.2 */
-      execute immediate q'[ALTER SESSION SET plscope_settings='IDENTIFIERS:#0#, STATEMENTS:#1#']';
+      execute immediate q'{ALTER SESSION SET plscope_settings='IDENTIFIERS:#0#, STATEMENTS:#1#'}';
    end if;
+
+   /* Compile public synonyms */
    if not (dbms_db_version.version = 11 and dbms_db_version.version = 1) and '#3#' = 'Yes' then
       /* Compilation of synonyms have been introduced with EBR in 11.2 */
-      <<synonyms>>
-      for r in (
-         select synonym_name
-           from all_synonyms
-          where owner = user
-      )
-      loop
-         execute immediate 'ALTER SYNONYM "'
-            || r.synonym_name
-            || '" COMPILE';
-      end loop synonyms;
       <<public_synonyms>>
       for r in (
          select synonym_name
-           from sys.all_synonyms
+           from sys.#5#_synonyms
           where owner = 'PUBLIC'
-            and table_owner = user
+            and table_owner = q'#"OBJECT_OWNER"#'
       )
       loop
          <<compile_public_synonym>>
          begin
-            execute immediate 'ALTER PUBLIC SYNONYM "'
-               || r.synonym_name
-               || '" COMPILE';
+            execute immediate 'ALTER PUBLIC SYNONYM '
+               || dbms_assert.enquote_name(r.synonym_name, false)
+               || ' COMPILE';
          exception
             when e_no_privs then
                /* ignore when user does not have create public synonym and drop public synonym privileges */
@@ -77,32 +94,53 @@ begin
          end compile_public_synonym;
       end loop public_synonyms;
    end if;
+
+   /* Compile private synonyms */
+   if not (dbms_db_version.version = 11 and dbms_db_version.version = 1) and '#4#' = 'Yes' then
+      /* Compilation of synonyms have been introduced with EBR in 11.2 */
+      <<synonyms>>
+      for r in (
+         select owner, synonym_name
+           from sys.#5#_synonyms
+          where owner = q'#"OBJECT_OWNER"#'
+      )
+      loop
+         execute immediate 'ALTER SYNONYM '
+            || dbms_assert.enquote_name(r.owner, false)
+            || '.' || dbms_assert.enquote_name(r.synonym_name, false)
+            || ' COMPILE';
+      end loop synonyms;
+   end if;
+
+   /* Compile code */
    if '#2#' = 'Yes' then
       /* Compile types */
       <<types>>
       for r in (
-         select o.object_type, o.object_name, count(d.name) as priority
-           from sys.all_objects o
-           left join all_dependencies d
+         select o.owner, o.object_type, o.object_name, count(d.name) as priority
+           from sys.#5#_objects o
+           left join #5#_dependencies d
              on d.owner = o.owner
             and d.type = o.object_type
             and d.name = o.object_name
-          where o.owner = user
+          where o.owner = q'#"OBJECT_OWNER"#'
             and o.object_type in ('TYPE', 'TYPE BODY')
-          group by o.object_type, o.object_name
+          group by o.owner, o.object_type, o.object_name
           order by priority
       )
       loop
          <<compile_type>>
          begin
             if r.object_type = 'TYPE' then
-               execute immediate 'ALTER TYPE "'
-                  || r.object_name
-                  || '" COMPILE';
+               execute immediate 'ALTER TYPE '
+                  || dbms_assert.enquote_name(r.owner, false)
+                  || '.' || dbms_assert.enquote_name(r.object_name, false)
+                  || ' COMPILE';
             else
-               execute immediate 'ALTER TYPE "'
-                  || r.object_name
-                  || '" COMPILE BODY';
+               execute immediate 'ALTER TYPE '
+                  || dbms_assert.enquote_name(r.owner, false)
+                  || '.' || dbms_assert.enquote_name(r.object_name, false)
+                  || ' COMPILE BODY';
             end if;
          exception
             when e_is_not_udt then
@@ -113,9 +151,10 @@ begin
                null;
          end compile_type;
       end loop types;
-      /* Compile schema handles procedures, functions, packages, views and triggers only */
+
+      /* compile_schema handles procedures, functions, packages, views and triggers only */
       dbms_utility.compile_schema(
-         schema         => user,
+         schema         => q'#"OBJECT_OWNER"#',
          compile_all    => true,
          reuse_settings => false
       );
@@ -132,23 +171,49 @@ end;
 	<!-- Copy of the previous item. Changed type only. A menu cannot be assigned to multiple nodes. -->
 	<item connType="Oracle" type="plscope-utils-root" reload="true" minversion="11.1">
 		<title>Compile with PL/Scope...</title>
-		<prompt type="radio">
+		<prompt type="radio">                               <!-- index: 0 -->
 			<label>Identifiers</label>
 			<value><![CDATA[STATIC:ALL:NONE:PUBLIC:SQL:PLSQL]]></value>
 		</prompt>
-		<prompt type="radio">
+		<prompt type="radio">                               <!-- index: 1 -->
 			<label>Statements</label>
 			<value><![CDATA[STATIC:ALL:NONE]]></value>
 		</prompt>
-		<prompt>
+		<prompt>                                            <!-- index: 2 -->
 			<label>Compile Code?</label>
 			<value><![CDATA[STATIC:Yes:No]]>
 			</value>
 		</prompt>
-		<prompt>
-			<label>Compile Synonyms?</label>
+		<prompt>                                            <!-- index: 3 -->
+			<label>Compile Public Synonyms?</label>
 			<value><![CDATA[STATIC:Yes:No]]>
 			</value>
+		</prompt>
+		<prompt>                                            <!-- index: 4 -->
+			<label>Compile Private Synonyms?</label>
+			<value><![CDATA[STATIC:Yes:No]]>
+			</value>
+		</prompt>
+        <prompt type="radio">                               <!-- index: 5 -->
+            <label>Use DBA or ALL views?</label>
+            <default><![CDATA[
+select case
+          when count(*) = 3 then
+             'Dba'
+          else
+             'All'
+       end as default_value
+  from all_views
+ where owner = 'SYS'
+   and view_name in ( 'DBA_OBJECTS',
+                      'DBA_SYNONYMS',
+                      'DBA_DEPENDENCIES' )
+]]>
+            </default>
+			<value><![CDATA[STATIC:Dba:All]]></value>
+        </prompt>
+		<prompt type="confirm">                             <!-- index: 6 -->
+			<label>Confirm actions for target schema: #"OBJECT_OWNER"# ?</label>
 		</prompt>
 		<sql>
 			<![CDATA[
@@ -164,37 +229,28 @@ begin
       dbms_db_version.version = 12 and dbms_db_version.release = 1
    then
       /* PL/Scope identifiers since 11.1 */
-      execute immediate q'[ALTER SESSION SET plscope_settings='IDENTIFIERS:#0#']';
+      execute immediate q'{ALTER SESSION SET plscope_settings='IDENTIFIERS:#0#'}';
    else
       /* PL/Scope statements since 12.2 */
-      execute immediate q'[ALTER SESSION SET plscope_settings='IDENTIFIERS:#0#, STATEMENTS:#1#']';
+      execute immediate q'{ALTER SESSION SET plscope_settings='IDENTIFIERS:#0#, STATEMENTS:#1#'}';
    end if;
+
+   /* Compile public synonyms */
    if not (dbms_db_version.version = 11 and dbms_db_version.version = 1) and '#3#' = 'Yes' then
       /* Compilation of synonyms have been introduced with EBR in 11.2 */
-      <<synonyms>>
-      for r in (
-         select synonym_name
-           from all_synonyms
-          where owner = user
-      )
-      loop
-         execute immediate 'ALTER SYNONYM "'
-            || r.synonym_name
-            || '" COMPILE';
-      end loop synonyms;
       <<public_synonyms>>
       for r in (
          select synonym_name
-           from sys.all_synonyms
+           from sys.#5#_synonyms
           where owner = 'PUBLIC'
-            and table_owner = user
+            and table_owner = q'#"OBJECT_OWNER"#'
       )
       loop
          <<compile_public_synonym>>
          begin
-            execute immediate 'ALTER PUBLIC SYNONYM "'
-               || r.synonym_name
-               || '" COMPILE';
+            execute immediate 'ALTER PUBLIC SYNONYM '
+               || dbms_assert.enquote_name(r.synonym_name, false)
+               || ' COMPILE';
          exception
             when e_no_privs then
                /* ignore when user does not have create public synonym and drop public synonym privileges */
@@ -202,32 +258,53 @@ begin
          end compile_public_synonym;
       end loop public_synonyms;
    end if;
+
+   /* Compile private synonyms */
+   if not (dbms_db_version.version = 11 and dbms_db_version.version = 1) and '#4#' = 'Yes' then
+      /* Compilation of synonyms have been introduced with EBR in 11.2 */
+      <<synonyms>>
+      for r in (
+         select owner, synonym_name
+           from sys.#5#_synonyms
+          where owner = q'#"OBJECT_OWNER"#'
+      )
+      loop
+         execute immediate 'ALTER SYNONYM '
+            || dbms_assert.enquote_name(r.owner, false)
+            || '.' || dbms_assert.enquote_name(r.synonym_name, false)
+            || ' COMPILE';
+      end loop synonyms;
+   end if;
+
+   /* Compile code */
    if '#2#' = 'Yes' then
       /* Compile types */
       <<types>>
       for r in (
-         select o.object_type, o.object_name, count(d.name) as priority
-           from sys.all_objects o
-           left join all_dependencies d
+         select o.owner, o.object_type, o.object_name, count(d.name) as priority
+           from sys.#5#_objects o
+           left join #5#_dependencies d
              on d.owner = o.owner
             and d.type = o.object_type
             and d.name = o.object_name
-          where o.owner = user
+          where o.owner = q'#"OBJECT_OWNER"#'
             and o.object_type in ('TYPE', 'TYPE BODY')
-          group by o.object_type, o.object_name
+          group by o.owner, o.object_type, o.object_name
           order by priority
       )
       loop
          <<compile_type>>
          begin
             if r.object_type = 'TYPE' then
-               execute immediate 'ALTER TYPE "'
-                  || r.object_name
-                  || '" COMPILE';
+               execute immediate 'ALTER TYPE '
+                  || dbms_assert.enquote_name(r.owner, false)
+                  || '.' || dbms_assert.enquote_name(r.object_name, false)
+                  || ' COMPILE';
             else
-               execute immediate 'ALTER TYPE "'
-                  || r.object_name
-                  || '" COMPILE BODY';
+               execute immediate 'ALTER TYPE '
+                  || dbms_assert.enquote_name(r.owner, false)
+                  || '.' || dbms_assert.enquote_name(r.object_name, false)
+                  || ' COMPILE BODY';
             end if;
          exception
             when e_is_not_udt then
@@ -238,9 +315,10 @@ begin
                null;
          end compile_type;
       end loop types;
-      /* Compile schema handles procedures, functions, packages, views and triggers only */
+
+      /* compile_schema handles procedures, functions, packages, views and triggers only */
       dbms_utility.compile_schema(
-         schema         => user,
+         schema         => q'#"OBJECT_OWNER"#',
          compile_all    => true,
          reuse_settings => false
       );
@@ -252,6 +330,6 @@ end;
 			<title>Confirmation</title>
 			<prompt>Compilation with PL/Scope completed.</prompt>
 		</confirmation>
-	</item>
+    </item>
 
 </items>

--- a/sqldev/src/main/resources/com/salvis/plscope/sqldev/action/compile_with_plscope.xml
+++ b/sqldev/src/main/resources/com/salvis/plscope/sqldev/action/compile_with_plscope.xml
@@ -34,7 +34,7 @@
             <label>Use DBA or ALL views?</label>
             <default><![CDATA[
 select case
-          when count(*) = 3 then
+          when count(*) = 4 then
              'Dba'
           else
              'All'
@@ -43,7 +43,8 @@ select case
  where owner = 'SYS'
    and view_name in ( 'DBA_OBJECTS',
                       'DBA_SYNONYMS',
-                      'DBA_DEPENDENCIES' )
+                      'DBA_DEPENDENCIES',
+                      'DBA_PLSQL_OBJECT_SETTINGS' )
 ]]>
             </default>
 			<value><![CDATA[STATIC:Dba:All]]></value>
@@ -69,6 +70,27 @@ begin
    else
       /* PL/Scope statements since 12.2 */
       execute immediate q'{ALTER SESSION SET plscope_settings='IDENTIFIERS:#0#, STATEMENTS:#1#'}';
+   end if;
+
+   if '#2#' = 'Yes' then
+      /* Make sure that PLSQL_CCFLAGS is not used in the target schema */
+      <<schema_has_ccflags_check>>
+      declare
+         l_cnt number;
+      begin
+         select count(*) into l_cnt
+           from #5#_plsql_object_settings
+          where owner = q'#"OBJECT_OWNER"#'
+            and plsql_ccflags is not null;
+
+         if l_cnt > 0 then
+            /* Schemas using plsql_ccflags are not supported in this action. */
+            raise_application_error(-20000,
+               'Unsupported: PLSQL_CCFLAGS is used in the '
+               || dbms_assert.enquote_name(q'#"OBJECT_OWNER"#', false)
+               || ' schema');
+         end if;
+      end schema_has_ccflags_check;
    end if;
 
    /* Compile public synonyms */
@@ -198,7 +220,7 @@ end;
             <label>Use DBA or ALL views?</label>
             <default><![CDATA[
 select case
-          when count(*) = 3 then
+          when count(*) = 4 then
              'Dba'
           else
              'All'
@@ -207,7 +229,8 @@ select case
  where owner = 'SYS'
    and view_name in ( 'DBA_OBJECTS',
                       'DBA_SYNONYMS',
-                      'DBA_DEPENDENCIES' )
+                      'DBA_DEPENDENCIES',
+                      'DBA_PLSQL_OBJECT_SETTINGS' )
 ]]>
             </default>
 			<value><![CDATA[STATIC:Dba:All]]></value>
@@ -233,6 +256,27 @@ begin
    else
       /* PL/Scope statements since 12.2 */
       execute immediate q'{ALTER SESSION SET plscope_settings='IDENTIFIERS:#0#, STATEMENTS:#1#'}';
+   end if;
+
+   if '#2#' = 'Yes' then
+      /* Make sure that PLSQL_CCFLAGS is not used in the target schema */
+      <<schema_has_ccflags_check>>
+      declare
+         l_cnt number;
+      begin
+         select count(*) into l_cnt
+           from #5#_plsql_object_settings
+          where owner = q'#"OBJECT_OWNER"#'
+            and plsql_ccflags is not null;
+
+         if l_cnt > 0 then
+            /* Schemas using plsql_ccflags are not supported in this action. */
+            raise_application_error(-20000,
+               'Unsupported: PLSQL_CCFLAGS is used in the '
+               || dbms_assert.enquote_name(q'#"OBJECT_OWNER"#', false)
+               || ' schema');
+         end if;
+      end schema_has_ccflags_check;
    end if;
 
    /* Compile public synonyms */

--- a/sqldev/src/main/resources/com/salvis/plscope/sqldev/report/plscope-utils-reports.xml
+++ b/sqldev/src/main/resources/com/salvis/plscope/sqldev/report/plscope-utils-reports.xml
@@ -3090,11 +3090,13 @@ Note: this report requires DBA privileges.]]></description>
        table_name,
        object_type      as target_object_type,
        is_with_plscope,
+       status           as syn_status,
        created          as synonym_created,
        last_ddl_time    as synonym_last_ddl_time
   from (
           select osrc.owner,
                  syn.synonym_name,
+                 osrc.status,
                  syn.table_owner,
                  syn.table_name,
                  nvl(odst.object_type, 'NON-EXISTENT')  as object_type,

--- a/sqldev/src/main/resources/com/salvis/plscope/sqldev/report/plscope-utils-reports.xml
+++ b/sqldev/src/main/resources/com/salvis/plscope/sqldev/report/plscope-utils-reports.xml
@@ -1,19 +1,23 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <displays>
 <folder>
-	<name><![CDATA[plscope-utils Reports]]></name>
-	<tooltip><![CDATA[PL/Scope reports]]></tooltip>
-	<description><![CDATA[PL/Scope reports provided by plscope-utils, see https://github.com/PhilippSalvisberg/plscope-utils ]]></description>
-		<display id="1dc49f53-015d-1000-8001-c0a8011251fe" type="" style="Table" enable="true">
-		<name><![CDATA[Duplicate SQL Statements]]></name>
-		<description><![CDATA[Reports duplicate static SQL statements within packages, procedures, functions, triggers and types. ]]></description>
-		<tooltip><![CDATA[Reports duplicate static SQL statements]]></tooltip>
-		<drillclass><![CDATA[]]></drillclass>
-		<CustomValues>
-			<TYPE><![CDATA[horizontal]]></TYPE>
-		</CustomValues>
-		<query minversion="12.2">
-			<sql><![CDATA[
+    <name><![CDATA[plscope-utils Reports]]></name>
+    <tooltip><![CDATA[PL/Scope reports]]></tooltip>
+    <description><![CDATA[PL/Scope reports provided by plscope-utils, see https://github.com/PhilippSalvisberg/plscope-utils ]]></description>
+    <folder>
+        <name><![CDATA[Main reports]]></name>
+        <tooltip><![CDATA[Main PL/Scope reports (for unprivileged users)]]></tooltip>
+        <description><![CDATA[Main sub-folder, containing reports which do not require special privileges]]></description>
+        <display id="1dc49f53-015d-1000-8001-c0a8011251fe" type="" style="Table" enable="true">
+            <name><![CDATA[Duplicate SQL Statements]]></name>
+            <description><![CDATA[Reports duplicate static SQL statements within packages, procedures, functions, triggers and types. ]]></description>
+            <tooltip><![CDATA[Reports duplicate static SQL statements]]></tooltip>
+            <drillclass><![CDATA[]]></drillclass>
+            <CustomValues>
+                <TYPE><![CDATA[horizontal]]></TYPE>
+            </CustomValues>
+            <query minversion="12.2">
+                <sql><![CDATA[
 with
    plscope_statements as (
       select owner,
@@ -75,16 +79,16 @@ select case
  where is_duplicate = 'YES'
  order by owner, object_type, object_name, sql_id, line, col
 ]]>
-         </sql>
-			<binds>
-				<bind id="OBJECT_OWNER">
-					<prompt><![CDATA[Owner like]]></prompt>
-					<tooltip><![CDATA[OBJECT_OWNER]]></tooltip>
-					<value><![CDATA[NULL_VALUE]]></value>
-					<bracket><![CDATA[null]]></bracket>
-				</bind>
-			</binds>
-		</query>
+                </sql>
+                <binds>
+                    <bind id="OBJECT_OWNER">
+                        <prompt><![CDATA[Owner like]]></prompt>
+                        <tooltip><![CDATA[OBJECT_OWNER]]></tooltip>
+                        <value><![CDATA[NULL_VALUE]]></value>
+                        <bracket><![CDATA[null]]></bracket>
+                    </bind>
+                </binds>
+            </query>
 			<pdf version="VERSION_1_7" compression="CONTENT">
 				<docproperty title="" author="" subject="" keywords="" />
 				<cell toppadding="2" bottompadding="2" leftpadding="2" rightpadding="2" horizontalalign="LEFT" verticalalign="TOP" wrap="true" />
@@ -105,17 +109,17 @@ select case
 				</footer>
 				<pagesetup papersize="LETTER" orientation="1" measurement="in" margintop="1.0" marginbottom="1.0" marginleft="1.0" marginright="1.0" />
 			</pdf>
-	</display>
-	<display id="27802dea-015d-1000-8001-c0a80106a1a4" type="" style="Table" enable="true">
-		<name><![CDATA[UDF Calls in SQL Statements]]></name>
-		<description><![CDATA[Reports static SELECT, INSERT, UPDATE, DELETE and MERGE statements within packages, procedures, functions, triggers and types using user-defined function calls.]]></description>
-		<tooltip><![CDATA[Reports user-defined function calls in SQL statements]]></tooltip>
-		<drillclass><![CDATA[]]></drillclass>
-		<CustomValues>
-			<TYPE><![CDATA[horizontal]]></TYPE>
-		</CustomValues>
-		<query minversion="12.2">
-			<sql><![CDATA[
+        </display>
+        <display id="27802dea-015d-1000-8001-c0a80106a1a4" type="" style="Table" enable="true">
+            <name><![CDATA[UDF Calls in SQL Statements]]></name>
+            <description><![CDATA[Reports static SELECT, INSERT, UPDATE, DELETE and MERGE statements within packages, procedures, functions, triggers and types using user-defined function calls.]]></description>
+            <tooltip><![CDATA[Reports user-defined function calls in SQL statements]]></tooltip>
+            <drillclass><![CDATA[]]></drillclass>
+            <CustomValues>
+                <TYPE><![CDATA[horizontal]]></TYPE>
+            </CustomValues>
+            <query minversion="12.2">
+                <sql><![CDATA[
    with
       -- database source filtered by user
       src as (
@@ -644,16 +648,16 @@ select case
    and not (ref_owner = 'SYS' and ref_object_type = 'PACKAGE' and ref_object_name = 'STANDARD')
  order by owner, object_type, object_name, line, col
  ]]>
-            </sql>
-			<binds>
-				<bind id="OBJECT_OWNER">
-					<prompt><![CDATA[Owner like]]></prompt>
-					<tooltip><![CDATA[OBJECT_OWNER]]></tooltip>
-					<value><![CDATA[NULL_VALUE]]></value>
-					<bracket><![CDATA[null]]></bracket>
-				</bind>
-			</binds>
-		</query>
+                </sql>
+                <binds>
+                    <bind id="OBJECT_OWNER">
+                        <prompt><![CDATA[Owner like]]></prompt>
+                        <tooltip><![CDATA[OBJECT_OWNER]]></tooltip>
+                        <value><![CDATA[NULL_VALUE]]></value>
+                        <bracket><![CDATA[null]]></bracket>
+                    </bind>
+                </binds>
+            </query>
 			<pdf version="VERSION_1_7" compression="CONTENT">
 				<docproperty title="" author="" subject="" keywords="" />
 				<cell toppadding="2" bottompadding="2" leftpadding="2" rightpadding="2" horizontalalign="LEFT" verticalalign="TOP" wrap="true" />
@@ -673,17 +677,17 @@ select case
 				</footer>
 				<pagesetup papersize="LETTER" orientation="1" measurement="in" margintop="1.0" marginbottom="1.0" marginleft="1.0" marginright="1.0" />
 			</pdf>
-	</display>
-	<display id="27d1dbe9-015d-1000-8001-c0a801060752" type="" style="Table" enable="true">
-		<name><![CDATA[CRUD Operations]]></name>
-		<description><![CDATA[Reports static usages of tables/views/synonyms within packages, procedures, functions, triggers and types. Reports number of SELECT, INSERT, UPDATE, DELETE, MERGE, REFERENCE usages per PL/SQL unit ]]></description>
-		<tooltip><![CDATA[Number of select, insert, update, delete, merge, reference usages per PL/SQL unit.]]></tooltip>
-		<drillclass><![CDATA[]]></drillclass>
-		<CustomValues>
-			<TYPE><![CDATA[horizontal]]></TYPE>
-		</CustomValues>
-		<query minversion="12.2">
-			<sql><![CDATA[
+        </display>
+        <display id="27d1dbe9-015d-1000-8001-c0a801060752" type="" style="Table" enable="true">
+            <name><![CDATA[CRUD Operations]]></name>
+            <description><![CDATA[Reports static usages of tables/views/synonyms within packages, procedures, functions, triggers and types. Reports number of SELECT, INSERT, UPDATE, DELETE, MERGE, REFERENCE usages per PL/SQL unit ]]></description>
+            <tooltip><![CDATA[Number of select, insert, update, delete, merge, reference usages per PL/SQL unit.]]></tooltip>
+            <drillclass><![CDATA[]]></drillclass>
+            <CustomValues>
+                <TYPE><![CDATA[horizontal]]></TYPE>
+            </CustomValues>
+            <query minversion="12.2">
+                <sql><![CDATA[
 with
    -- database source filtered by user
    src as (
@@ -1374,16 +1378,16 @@ select case
  group by owner, object_type, object_name, procedure_name, ref_owner, ref_object_type, ref_object_name
  order by owner, object_type, object_name, procedure_name, ref_owner, ref_object_type, ref_object_name
 ]]>
-         </sql>
-			<binds>
-				<bind id="OBJECT_OWNER">
-					<prompt><![CDATA[Owner like]]></prompt>
-					<tooltip><![CDATA[OBJECT_OWNER]]></tooltip>
-					<value><![CDATA[NULL_VALUE]]></value>
-					<bracket><![CDATA[null]]></bracket>
-				</bind>
-			</binds>
-		</query>
+                </sql>
+                <binds>
+                    <bind id="OBJECT_OWNER">
+                        <prompt><![CDATA[Owner like]]></prompt>
+                        <tooltip><![CDATA[OBJECT_OWNER]]></tooltip>
+                        <value><![CDATA[NULL_VALUE]]></value>
+                        <bracket><![CDATA[null]]></bracket>
+                    </bind>
+                </binds>
+            </query>
 			<pdf version="VERSION_1_7" compression="CONTENT">
 				<docproperty title="" author="" subject="" keywords="" />
 				<cell toppadding="2" bottompadding="2" leftpadding="2" rightpadding="2" horizontalalign="LEFT" verticalalign="TOP" wrap="true" />
@@ -1402,17 +1406,17 @@ select case
 				</footer>
 				<pagesetup papersize="LETTER" orientation="1" measurement="in" margintop="1.0" marginbottom="1.0" marginleft="1.0" marginright="1.0" />
 			</pdf>
-	</display>
-	<display id="2e3cb6a6-015d-1000-8001-c0a801126c36" type="" style="Table" enable="true">
-		<name><![CDATA[Unused Local Identifiers]]></name>
-		<description><![CDATA[Reports locally declared identifiers in within packages, procedures, functions, triggers and types which are not referenced.]]></description>
-		<tooltip><![CDATA[Reports unreferenced locally defined identifiers]]></tooltip>
-		<drillclass><![CDATA[]]></drillclass>
-		<CustomValues>
-			<TYPE><![CDATA[horizontal]]></TYPE>
-		</CustomValues>
-		<query minversion="12.2">
-			<sql><![CDATA[
+        </display>
+        <display id="2e3cb6a6-015d-1000-8001-c0a801126c36" type="" style="Table" enable="true">
+            <name><![CDATA[Unused Local Identifiers]]></name>
+            <description><![CDATA[Reports locally declared identifiers in within packages, procedures, functions, triggers and types which are not referenced.]]></description>
+            <tooltip><![CDATA[Reports unreferenced locally defined identifiers]]></tooltip>
+            <drillclass><![CDATA[]]></drillclass>
+            <CustomValues>
+                <TYPE><![CDATA[horizontal]]></TYPE>
+            </CustomValues>
+            <query minversion="12.2">
+                <sql><![CDATA[
 with
    -- database source filtered by user
    src as (
@@ -1937,18 +1941,18 @@ select case
    and is_used = 'NO'
  order by owner, object_type, object_name, line, col
  ]]>
-         </sql>
-			<binds>
-				<bind id="OBJECT_OWNER">
-					<prompt><![CDATA[Owner like]]></prompt>
-					<tooltip><![CDATA[OBJECT_OWNER]]></tooltip>
-					<value><![CDATA[NULL_VALUE]]></value>
-					<bracket><![CDATA[null]]></bracket>
-				</bind>
-			</binds>
-		</query>
-		<query minversion="11.1">
-			<sql><![CDATA[
+                </sql>
+                <binds>
+                    <bind id="OBJECT_OWNER">
+                        <prompt><![CDATA[Owner like]]></prompt>
+                        <tooltip><![CDATA[OBJECT_OWNER]]></tooltip>
+                        <value><![CDATA[NULL_VALUE]]></value>
+                        <bracket><![CDATA[null]]></bracket>
+                    </bind>
+                </binds>
+            </query>
+            <query minversion="11.1">
+                <sql><![CDATA[
 with
    -- database source filtered by user
    src as (
@@ -2442,16 +2446,16 @@ select case
    and is_used = 'NO'
  order by owner, object_type, object_name, line, col
  ]]>
-			</sql>
-			<binds>
-				<bind id="OBJECT_OWNER">
-					<prompt><![CDATA[Owner like]]></prompt>
-					<tooltip><![CDATA[OBJECT_OWNER]]></tooltip>
-					<value><![CDATA[NULL_VALUE]]></value>
-					<bracket><![CDATA[null]]></bracket>
-				</bind>
-			</binds>
-		</query>
+                </sql>
+                <binds>
+                    <bind id="OBJECT_OWNER">
+                        <prompt><![CDATA[Owner like]]></prompt>
+                        <tooltip><![CDATA[OBJECT_OWNER]]></tooltip>
+                        <value><![CDATA[NULL_VALUE]]></value>
+                        <bracket><![CDATA[null]]></bracket>
+                    </bind>
+                </binds>
+            </query>
 			<pdf version="VERSION_1_7" compression="CONTENT">
 				<docproperty title="" author="" subject="" keywords="" />
 				<cell toppadding="2" bottompadding="2" leftpadding="2" rightpadding="2" horizontalalign="LEFT" verticalalign="TOP" wrap="true" />
@@ -2471,17 +2475,17 @@ select case
 				</footer>
 				<pagesetup papersize="LETTER" orientation="1" measurement="in" margintop="1.0" marginbottom="1.0" marginleft="1.0" marginright="1.0" />
 			</pdf>
-	</display>
-	<display id="9f38924a-015d-1000-8001-c0a80112c4cd" type="" style="Table" enable="true">
-		<name><![CDATA[PL/SQL Naming Conventions]]></name>
-		<description><![CDATA[Check PL/SQL identifiers based on the Trivadis PL/SQL & SQL Coding Guidelines V3.2]]></description>
-		<tooltip><![CDATA[Reports PL/SQL identifiers violationg naming conventions]]></tooltip>
-		<drillclass><![CDATA[]]></drillclass>
-		<CustomValues>
-			<TYPE><![CDATA[horizontal]]></TYPE>
-		</CustomValues>
-		<query minversion="11.1">
-			<sql><![CDATA[
+        </display>
+        <display id="9f38924a-015d-1000-8001-c0a80112c4cd" type="" style="Table" enable="true">
+            <name><![CDATA[PL/SQL Naming Conventions]]></name>
+            <description><![CDATA[Check PL/SQL identifiers based on the Trivadis PL/SQL & SQL Coding Guidelines V3.2]]></description>
+            <tooltip><![CDATA[Reports PL/SQL identifiers violationg naming conventions]]></tooltip>
+            <drillclass><![CDATA[]]></drillclass>
+            <CustomValues>
+                <TYPE><![CDATA[horizontal]]></TYPE>
+            </CustomValues>
+            <query minversion="11.1">
+                <sql><![CDATA[
 with
    src as (
       select /*+ materialize */
@@ -2946,106 +2950,106 @@ select case
  where message != 'OK'
  order by owner, object_type, object_name, line, col
  ]]>
-         </sql>
-			<binds>
-				<bind id="OBJECT_OWNER">
-					<prompt><![CDATA[Owner like]]></prompt>
-					<tooltip><![CDATA[OBJECT_OWNER]]></tooltip>
-					<value><![CDATA[NULL_VALUE]]></value>
-					<bracket><![CDATA[null]]></bracket>
-				</bind>
-				<bind id="GLOBAL_VARIABLE_REGEX">
-					<prompt><![CDATA[Global variable regex]]></prompt>
-					<tooltip><![CDATA[GLOBAL_VARIABLE_REGEX]]></tooltip>
-					<value><![CDATA[^g_.*]]></value>
-					<bracket><![CDATA[null]]></bracket>
-				</bind>
-				<bind id="LOCAL_RECORD_VARIABLE_REGEX">
-					<prompt><![CDATA[Local record variable regex]]></prompt>
-					<tooltip><![CDATA[LOCAL_RECORD_VARIABLE_REGEX]]></tooltip>
-					<value><![CDATA[^r_.*]]></value>
-					<bracket><![CDATA[null]]></bracket>
-				</bind>
-				<bind id="LOCAL_ARRAY_VARIABLE_REGEX">
-					<prompt><![CDATA[Local array/table variable regex]]></prompt>
-					<tooltip><![CDATA[LOCAL_ARRAY_VARIABLE_REGEX]]></tooltip>
-					<value><![CDATA[^t_.*]]></value>
-					<bracket><![CDATA[null]]></bracket>
-				</bind>
-				<bind id="LOCAL_OBJECT_VARIABLE_REGEX">
-					<prompt><![CDATA[Local object variable regex]]></prompt>
-					<tooltip><![CDATA[LOCAL_OBJECT_VARIABLE_REGEX]]></tooltip>
-					<value><![CDATA[^o_.*]]></value>
-					<bracket><![CDATA[null]]></bracket>
-				</bind>
-				<bind id="LOCAL_VARIABLE_REGEX">
-					<prompt><![CDATA[Local variable regex]]></prompt>
-					<tooltip><![CDATA[LOCAL_VARIABLE_REGEX]]></tooltip>
-					<value><![CDATA[^(l|c)_.*]]></value>
-					<bracket><![CDATA[null]]></bracket>
-				</bind>
-				<bind id="CURSOR_REGEX">
-					<prompt><![CDATA[Cursor regex]]></prompt>
-					<tooltip><![CDATA[CURSOR_REGEX]]></tooltip>
-					<value><![CDATA[^c_.*]]></value>
-					<bracket><![CDATA[null]]></bracket>
-				</bind>
-				<bind id="CURSOR_PARAMETER_REGEX">
-					<prompt><![CDATA[Cursor parameter regex]]></prompt>
-					<tooltip><![CDATA[CURSOR_PARAMETER_REGEX]]></tooltip>
-					<value><![CDATA[^p_.*]]></value>
-					<bracket><![CDATA[null]]></bracket>
-				</bind>
-				<bind id="IN_PARAMETER_REGEX">
-					<prompt><![CDATA[IN parameter regex]]></prompt>
-					<tooltip><![CDATA[IN_PARAMETER_REGEX]]></tooltip>
-					<value><![CDATA[^in_.*]]></value>
-					<bracket><![CDATA[null]]></bracket>
-				</bind>
-				<bind id="OUT_PARAMETER_REGEX">
-					<prompt><![CDATA[OUT parameter regex]]></prompt>
-					<tooltip><![CDATA[OUT_PARAMETER_REGEX]]></tooltip>
-					<value><![CDATA[^out_.*]]></value>
-					<bracket><![CDATA[null]]></bracket>
-				</bind>
-				<bind id="IN_OUT_PARAMETER_REGEX">
-					<prompt><![CDATA[IN OUT_parameter regex]]></prompt>
-					<tooltip><![CDATA[IN_OUT_PARAMETER_REGEX]]></tooltip>
-					<value><![CDATA[^io_.*]]></value>
-					<bracket><![CDATA[null]]></bracket>
-				</bind>
-				<bind id="RECORD_REGEX">
-					<prompt><![CDATA[Record regex]]></prompt>
-					<tooltip><![CDATA[RECORD_REGEX]]></tooltip>
-					<value><![CDATA[^r_.*_type$]]></value>
-					<bracket><![CDATA[null]]></bracket>
-				</bind>
-				<bind id="ARRAY_REGEX">
-					<prompt><![CDATA[Array/table regex]]></prompt>
-					<tooltip><![CDATA[ARRAY_REGEX]]></tooltip>
-					<value><![CDATA[^t_.*_type$|^.*_ct$]]></value>
-					<bracket><![CDATA[null]]></bracket>
-				</bind>
-				<bind id="EXCEPTION_REGEX">
-					<prompt><![CDATA[Exception regex]]></prompt>
-					<tooltip><![CDATA[EXCEPTION_REGEX]]></tooltip>
-					<value><![CDATA[^e_.*]]></value>
-					<bracket><![CDATA[null]]></bracket>
-				</bind>
-				<bind id="CONSTANT_REGEX">
-					<prompt><![CDATA[Constant regex]]></prompt>
-					<tooltip><![CDATA[CONSTANT_REGEX]]></tooltip>
-					<value><![CDATA[^co_.*]]></value>
-					<bracket><![CDATA[null]]></bracket>
-				</bind>
-				<bind id="SUBTYPE_REGEX">
-					<prompt><![CDATA[Subtype regex]]></prompt>
-					<tooltip><![CDATA[SUBTYPE_REGEX]]></tooltip>
-					<value><![CDATA[.*_type$]]></value>
-					<bracket><![CDATA[null]]></bracket>
-				</bind>
-			</binds>
-		</query>
+                </sql>
+                <binds>
+                    <bind id="OBJECT_OWNER">
+                        <prompt><![CDATA[Owner like]]></prompt>
+                        <tooltip><![CDATA[OBJECT_OWNER]]></tooltip>
+                        <value><![CDATA[NULL_VALUE]]></value>
+                        <bracket><![CDATA[null]]></bracket>
+                    </bind>
+                    <bind id="GLOBAL_VARIABLE_REGEX">
+                        <prompt><![CDATA[Global variable regex]]></prompt>
+                        <tooltip><![CDATA[GLOBAL_VARIABLE_REGEX]]></tooltip>
+                        <value><![CDATA[^g_.*]]></value>
+                        <bracket><![CDATA[null]]></bracket>
+                    </bind>
+                    <bind id="LOCAL_RECORD_VARIABLE_REGEX">
+                        <prompt><![CDATA[Local record variable regex]]></prompt>
+                        <tooltip><![CDATA[LOCAL_RECORD_VARIABLE_REGEX]]></tooltip>
+                        <value><![CDATA[^r_.*]]></value>
+                        <bracket><![CDATA[null]]></bracket>
+                    </bind>
+                    <bind id="LOCAL_ARRAY_VARIABLE_REGEX">
+                        <prompt><![CDATA[Local array/table variable regex]]></prompt>
+                        <tooltip><![CDATA[LOCAL_ARRAY_VARIABLE_REGEX]]></tooltip>
+                        <value><![CDATA[^t_.*]]></value>
+                        <bracket><![CDATA[null]]></bracket>
+                    </bind>
+                    <bind id="LOCAL_OBJECT_VARIABLE_REGEX">
+                        <prompt><![CDATA[Local object variable regex]]></prompt>
+                        <tooltip><![CDATA[LOCAL_OBJECT_VARIABLE_REGEX]]></tooltip>
+                        <value><![CDATA[^o_.*]]></value>
+                        <bracket><![CDATA[null]]></bracket>
+                    </bind>
+                    <bind id="LOCAL_VARIABLE_REGEX">
+                        <prompt><![CDATA[Local variable regex]]></prompt>
+                        <tooltip><![CDATA[LOCAL_VARIABLE_REGEX]]></tooltip>
+                        <value><![CDATA[^(l|c)_.*]]></value>
+                        <bracket><![CDATA[null]]></bracket>
+                    </bind>
+                    <bind id="CURSOR_REGEX">
+                        <prompt><![CDATA[Cursor regex]]></prompt>
+                        <tooltip><![CDATA[CURSOR_REGEX]]></tooltip>
+                        <value><![CDATA[^c_.*]]></value>
+                        <bracket><![CDATA[null]]></bracket>
+                    </bind>
+                    <bind id="CURSOR_PARAMETER_REGEX">
+                        <prompt><![CDATA[Cursor parameter regex]]></prompt>
+                        <tooltip><![CDATA[CURSOR_PARAMETER_REGEX]]></tooltip>
+                        <value><![CDATA[^p_.*]]></value>
+                        <bracket><![CDATA[null]]></bracket>
+                    </bind>
+                    <bind id="IN_PARAMETER_REGEX">
+                        <prompt><![CDATA[IN parameter regex]]></prompt>
+                        <tooltip><![CDATA[IN_PARAMETER_REGEX]]></tooltip>
+                        <value><![CDATA[^in_.*]]></value>
+                        <bracket><![CDATA[null]]></bracket>
+                    </bind>
+                    <bind id="OUT_PARAMETER_REGEX">
+                        <prompt><![CDATA[OUT parameter regex]]></prompt>
+                        <tooltip><![CDATA[OUT_PARAMETER_REGEX]]></tooltip>
+                        <value><![CDATA[^out_.*]]></value>
+                        <bracket><![CDATA[null]]></bracket>
+                    </bind>
+                    <bind id="IN_OUT_PARAMETER_REGEX">
+                        <prompt><![CDATA[IN OUT_parameter regex]]></prompt>
+                        <tooltip><![CDATA[IN_OUT_PARAMETER_REGEX]]></tooltip>
+                        <value><![CDATA[^io_.*]]></value>
+                        <bracket><![CDATA[null]]></bracket>
+                    </bind>
+                    <bind id="RECORD_REGEX">
+                        <prompt><![CDATA[Record regex]]></prompt>
+                        <tooltip><![CDATA[RECORD_REGEX]]></tooltip>
+                        <value><![CDATA[^r_.*_type$]]></value>
+                        <bracket><![CDATA[null]]></bracket>
+                    </bind>
+                    <bind id="ARRAY_REGEX">
+                        <prompt><![CDATA[Array/table regex]]></prompt>
+                        <tooltip><![CDATA[ARRAY_REGEX]]></tooltip>
+                        <value><![CDATA[^t_.*_type$|^.*_ct$]]></value>
+                        <bracket><![CDATA[null]]></bracket>
+                    </bind>
+                    <bind id="EXCEPTION_REGEX">
+                        <prompt><![CDATA[Exception regex]]></prompt>
+                        <tooltip><![CDATA[EXCEPTION_REGEX]]></tooltip>
+                        <value><![CDATA[^e_.*]]></value>
+                        <bracket><![CDATA[null]]></bracket>
+                    </bind>
+                    <bind id="CONSTANT_REGEX">
+                        <prompt><![CDATA[Constant regex]]></prompt>
+                        <tooltip><![CDATA[CONSTANT_REGEX]]></tooltip>
+                        <value><![CDATA[^co_.*]]></value>
+                        <bracket><![CDATA[null]]></bracket>
+                    </bind>
+                    <bind id="SUBTYPE_REGEX">
+                        <prompt><![CDATA[Subtype regex]]></prompt>
+                        <tooltip><![CDATA[SUBTYPE_REGEX]]></tooltip>
+                        <value><![CDATA[.*_type$]]></value>
+                        <bracket><![CDATA[null]]></bracket>
+                    </bind>
+                </binds>
+            </query>
 			<pdf version="VERSION_1_7" compression="CONTENT">
 				<docproperty title="" author="" subject="" keywords="" />
 				<cell toppadding="2" bottompadding="2" leftpadding="2" rightpadding="2" horizontalalign="LEFT" verticalalign="TOP" wrap="true" />
@@ -3064,6 +3068,246 @@ select case
 				</footer>
 				<pagesetup papersize="LETTER" orientation="1" measurement="in" margintop="1.0" marginbottom="1.0" marginleft="1.0" marginright="1.0" />
 			</pdf>
-	</display>
+        </display>
+    </folder>
+    <folder>
+        <name><![CDATA[Other reports]]></name>
+        <tooltip><![CDATA[Other PL/Scope reports (may require DBA privileges)]]></tooltip>
+        <description><![CDATA[Sub-folder for reports of secondary interest, or which require DBA-level privileges]]></description>
+        <display id="18e04d5a-19e6-4f76-9991-5d2118dab487" type="" style="Table" enable="true">
+            <name><![CDATA[Synonyms with/wo PL/Scope]]></name>
+            <description><![CDATA[This reports helps find out which synonyms have been compiled with or without PL/Scope.
+Note: this report requires DBA privileges.]]></description>
+            <tooltip><![CDATA[Synonyms compiled with or without PL/Scope  ## DBA privileges needed ##]]></tooltip>
+            <drillclass><![CDATA[]]></drillclass>
+            <CustomValues>
+                <TYPE><![CDATA[horizontal]]></TYPE>
+            </CustomValues>
+            <query>
+                <sql><![CDATA[select owner            as synonym_owner,
+       synonym_name     as synonym_name,
+       table_owner,
+       table_name,
+       object_type      as target_object_type,
+       is_with_plscope,
+       created          as synonym_created,
+       last_ddl_time    as synonym_last_ddl_time
+  from (
+          select osrc.owner,
+                 syn.synonym_name,
+                 syn.table_owner,
+                 syn.table_name,
+                 nvl(odst.object_type, 'NON-EXISTENT')  as object_type,
+                 case
+                    when pli.signature is not null then
+                       'YES'
+                 end                                    as is_with_plscope,
+                 osrc.created,
+                 osrc.last_ddl_time
+            from sys.dba_synonyms        syn,
+                 sys.dba_objects         osrc,
+                 sys.dba_objects         odst,
+                 sys.plscope_identifier$ pli
+           where syn.table_owner = odst.owner (+)
+             and syn.table_name = odst.object_name (+)
+             and odst.subobject_name (+) is null
+             and odst.namespace (+) = 1
+             and syn.owner = osrc.owner
+             and syn.synonym_name = osrc.object_name
+             and osrc.object_type = 'SYNONYM'
+             and osrc.object_id = pli.obj# (+)
+             and osrc.object_name = pli.symrep (+)
+             and pli.type# (+) = 37 /* synonym */
+             and /* positive filters on synonym name */
+                 case
+                    when :B_SYN_LIKE is null
+                       and :B_SYN_RE is null
+                    then
+                       'Y'
+                    when (:B_SYN_LIKE is not null
+                          and upper(syn.synonym_name) like upper(:B_SYN_LIKE))
+                       or (:B_SYN_RE is not null
+                          and regexp_like(syn.synonym_name, :B_SYN_RE, 'i'))
+                    then
+                       'Y'
+                 end = 'Y'
+             and /* negative filters on synonym name */
+                 case
+                    when :B_SYN_NOT_LIKE is null
+                       and :B_SYN_NEG_RE is null
+                    then
+                       'Y'
+                    when (:B_SYN_NOT_LIKE is not null
+                          and upper(syn.synonym_name) like upper(:B_SYN_NOT_LIKE))
+                       or (:B_SYN_NEG_RE is not null
+                          and regexp_like(syn.synonym_name, :B_SYN_NEG_RE, 'i'))
+                    then
+                       'N'
+                    else
+                       'Y'
+                 end = 'Y'
+             and /* filter on object type */
+                 case
+                    when :B_OBJ_TYPE_LIKE is null then
+                       'Y'
+                    when :B_OBJ_TYPE_LIKE is not null
+                       and upper(odst.object_type) like upper(:B_OBJ_TYPE_LIKE)
+                    then
+                       'Y'
+                    when :B_OBJ_TYPE_LIKE is not null
+                       and odst.object_type is null
+                    then /* missing target */
+                       case
+                          when lnnvl(upper(substr(trim(:B_INCL_NON_EXISTENT), 1, 1)) = 'N') then
+                             'Y'
+                       end
+                 end = 'Y'
+             and /* 
+                    filters on the synonym's owner (private synonyms)
+                    and the target object's owner (public synonyms) 
+                  */
+                 case
+                    when lnnvl(upper(substr(trim(:B_WITH_PUBSYN), 1, 1)) = 'N')
+                       and osrc.owner = 'PUBLIC'
+                    then
+                       /* public synonyms */
+                       case
+                          when ((:B_OWNER_LIKE is null and :B_OWNER_RE is null)
+                                or (:B_OWNER_LIKE is not null 
+                                      and upper(syn.table_owner) like upper(:B_OWNER_LIKE))
+                                or (:B_OWNER_RE is not null 
+                                      and regexp_like(syn.table_owner, :B_OWNER_RE, 'i'))
+                             )
+                             and not
+                             ((:B_OWNER_NOT_LIKE is not null 
+                                  and upper(syn.table_owner) like upper(:B_OWNER_NOT_LIKE))
+                                or (:B_OWNER_NEG_RE is not null 
+                                      and regexp_like(syn.table_owner, :B_OWNER_NEG_RE, 'i'))
+                             )
+                          then
+                             'Y'
+                       end
+                    when lnnvl(upper(substr(trim(:B_WITH_PRIVSYN), 1, 1)) = 'N')
+                       and osrc.owner != 'PUBLIC'
+                    then
+                       /* private synonyms */
+                       case
+                          when ((:B_OWNER_LIKE is null and :B_OWNER_RE is null)
+                                or (:B_OWNER_LIKE is not null and upper(osrc.owner) like upper(:B_OWNER_LIKE))
+                                or (:B_OWNER_RE is not null and regexp_like(osrc.owner, :B_OWNER_RE, 'i'))
+                             )
+                             and not
+                             ((:B_OWNER_NOT_LIKE is not null and upper(osrc.owner) like upper(:B_OWNER_NOT_LIKE))
+                                or (:B_OWNER_NEG_RE is not null and regexp_like(osrc.owner, :B_OWNER_NEG_RE, 'i'))
+                             )
+                          then
+                             'Y'
+                       end
+                 end = 'Y'
+             and /* include or hide synonyms with non-existent target */
+                 (odst.owner is not null or lnnvl(upper(substr(trim(:B_INCL_NON_EXISTENT), 1, 1)) = 'N'))
+       )
+ where
+       /* filter on with or without PL/Scope */
+       case
+          when :B_IS_WITH_PLSCOPE is null then
+             'Y'
+          when upper(trim(:B_IS_WITH_PLSCOPE)) in ('Y', 'YES')
+             and is_with_plscope = 'YES'
+          then
+             'Y'
+          when upper(trim(:B_IS_WITH_PLSCOPE)) in ('N', 'NO')
+             and is_with_plscope is null
+          then
+             'Y'
+       end = 'Y'
+ order by owner,
+       table_owner,
+       synonym_name
+]]>
+                </sql>
+                <binds>
+                    <bind id="B_WITH_PUBSYN">
+                        <prompt><![CDATA[Include public synonyms?]]></prompt>
+                        <tooltip><![CDATA[Include public synonyms? (Y or null: include; N: exclude)]]></tooltip>
+                        <value><![CDATA[NULL_VALUE]]></value>
+                        <bracket><![CDATA[null]]></bracket>
+                    </bind>
+                    <bind id="B_WITH_PRIVSYN">
+                        <prompt><![CDATA[Include private synonyms?]]></prompt>
+                        <tooltip><![CDATA[Include private synonyms? (Y or null: include; N: exclude)]]></tooltip>
+                        <value><![CDATA[NULL_VALUE]]></value>
+                        <bracket><![CDATA[null]]></bracket>
+                    </bind>
+                    <bind id="B_IS_WITH_PLSCOPE">
+                        <prompt><![CDATA[Is compiled with PL/Scope?]]></prompt>
+                        <tooltip><![CDATA[Y: show only synonyms compiled with PL/Scope; N: without; null: both]]></tooltip>
+                        <value><![CDATA[NULL_VALUE]]></value>
+                        <bracket><![CDATA[null]]></bracket>
+                    </bind>
+                    <bind id="B_INCL_NON_EXISTENT">
+                        <prompt><![CDATA[Include non-existent targets?]]></prompt>
+                        <tooltip><![CDATA[Include synonyms with non-existent targets? (Y or null: include; N: exclude)]]></tooltip>
+                        <value><![CDATA[NULL_VALUE]]></value>
+                        <bracket><![CDATA[null]]></bracket>
+                    </bind>
+                    <bind id="B_OWNER_LIKE">
+                        <prompt><![CDATA[Owner like?]]></prompt>
+                        <tooltip><![CDATA[Show only public synonyms into, and private synonyms in, the matching schema (LIKE pattern, CI)]]></tooltip>
+                        <value><![CDATA[NULL_VALUE]]></value>
+                        <bracket><![CDATA[null]]></bracket>
+                    </bind>
+                    <bind id="B_OWNER_RE">
+                        <prompt><![CDATA[Owner regexp?]]></prompt>
+                        <tooltip><![CDATA[Show only public synonyms into, and private synonyms in, the matching schema (regexp, CI)]]></tooltip>
+                        <value><![CDATA[NULL_VALUE]]></value>
+                        <bracket><![CDATA[null]]></bracket>
+                    </bind>
+                    <bind id="B_OWNER_NOT_LIKE">
+                        <prompt><![CDATA[Owner not like?]]></prompt>
+                        <tooltip><![CDATA[Exclude public synonyms into, and private synonyms in, the matching schema (LIKE pattern, CI)]]></tooltip>
+                        <value><![CDATA[NULL_VALUE]]></value>
+                        <bracket><![CDATA[null]]></bracket>
+                    </bind>
+                    <bind id="B_OWNER_NEG_RE">
+                        <prompt><![CDATA[Owner negative regexp?]]></prompt>
+                        <tooltip><![CDATA[Exclude public synonyms into, and private synonyms in, the matching schema (regexp, CI)]]></tooltip>
+                        <value><![CDATA[NULL_VALUE]]></value>
+                        <bracket><![CDATA[null]]></bracket>
+                    </bind>
+                    <bind id="B_OBJ_TYPE_LIKE">
+                        <prompt><![CDATA[Target object type like?]]></prompt>
+                        <tooltip><![CDATA[Filter on the type of the target object (LIKE pattern, CI)]]></tooltip>
+                        <value><![CDATA[NULL_VALUE]]></value>
+                        <bracket><![CDATA[null]]></bracket>
+                    </bind>
+                    <bind id="B_SYN_LIKE">
+                        <prompt><![CDATA[Synonym name like?]]></prompt>
+                        <tooltip><![CDATA[Show only matching synonyms (LIKE pattern, CI)]]></tooltip>
+                        <value><![CDATA[NULL_VALUE]]></value>
+                        <bracket><![CDATA[null]]></bracket>
+                    </bind>
+                    <bind id="B_SYN_RE">
+                        <prompt><![CDATA[Synonym name RE?]]></prompt>
+                        <tooltip><![CDATA[Show only matching synonyms (regexp, CI)]]></tooltip>
+                        <value><![CDATA[NULL_VALUE]]></value>
+                        <bracket><![CDATA[null]]></bracket>
+                    </bind>
+                    <bind id="B_SYN_NOT_LIKE">
+                        <prompt><![CDATA[Synonym name not like?]]></prompt>
+                        <tooltip><![CDATA[Exclude matching synonyms (LIKE pattern, CI)]]></tooltip>
+                        <value><![CDATA[NULL_VALUE]]></value>
+                        <bracket><![CDATA[null]]></bracket>
+                    </bind>
+                    <bind id="B_SYN_NEG_RE">
+                        <prompt><![CDATA[Synonym name negative RE?]]></prompt>
+                        <tooltip><![CDATA[Exclude matching synonyms (regexp, CI)]]></tooltip>
+                        <value><![CDATA[NULL_VALUE]]></value>
+                        <bracket><![CDATA[null]]></bracket>
+                    </bind>
+                </binds>
+            </query>
+        </display>
+    </folder>
 </folder>
 </displays>

--- a/sqldev/src/test/java/com/salvis/plscope/sqldev/test/ActionTest.java
+++ b/sqldev/src/test/java/com/salvis/plscope/sqldev/test/ActionTest.java
@@ -30,9 +30,10 @@ public class ActionTest extends AbstractJdbcTest{
                     .replaceAll("#0#", "All")
                     .replaceAll("#1#", "ALL")
                     .replaceAll("#2#", "ALL")
-                    .replaceAll("#3#", "Yes")
+                    .replaceAll("#3#", "Yes, reuse settings")
                     .replaceAll("#4#", "Yes")
                     .replaceAll("#5#", "Yes")
+                    .replaceAll("#6#", "On - All details")
                     .replaceAll("#\"OBJECT_OWNER\"#", "\"" + dataSource.getUsername() + "\"");
             // ok if no exception is thrown
             jdbcTemplate.update(query);
@@ -48,6 +49,7 @@ public class ActionTest extends AbstractJdbcTest{
                     .replaceAll("#3#", "No")
                     .replaceAll("#4#", "No")
                     .replaceAll("#5#", "No")
+                    .replaceAll("#6#", "Off")
                     .replaceAll("#\"OBJECT_OWNER\"#", "\"" + dataSource.getUsername() + "\"");
             // ok if no exception is thrown
             jdbcTemplate.update(query);

--- a/sqldev/src/test/java/com/salvis/plscope/sqldev/test/ActionTest.java
+++ b/sqldev/src/test/java/com/salvis/plscope/sqldev/test/ActionTest.java
@@ -27,12 +27,12 @@ public class ActionTest extends AbstractJdbcTest{
         public void connection_node() {
             var node = xmlTools.getNode(doc, "//*[local-name()='item'][@type='CONNECTION']/*[local-name()='sql']");
             var query = node.getTextContent()
-                    .replaceAll("#0#", "ALL")
+                    .replaceAll("#0#", "All")
                     .replaceAll("#1#", "ALL")
-                    .replaceAll("#2#", "Yes")
+                    .replaceAll("#2#", "ALL")
                     .replaceAll("#3#", "Yes")
                     .replaceAll("#4#", "Yes")
-                    .replaceAll("#5#", "All")
+                    .replaceAll("#5#", "Yes")
                     .replaceAll("#\"OBJECT_OWNER\"#", "\"" + dataSource.getUsername() + "\"");
             // ok if no exception is thrown
             jdbcTemplate.update(query);
@@ -42,12 +42,12 @@ public class ActionTest extends AbstractJdbcTest{
         public void plscope_util_root_node() {
             var node = xmlTools.getNode(doc, "//*[local-name()='item'][@type='plscope-utils-root']/*[local-name()='sql']");
             var query = node.getTextContent()
-                    .replaceAll("#0#", "ALL")
+                    .replaceAll("#0#", "All")
                     .replaceAll("#1#", "ALL")
-                    .replaceAll("#2#", "No")
+                    .replaceAll("#2#", "ALL")
                     .replaceAll("#3#", "No")
                     .replaceAll("#4#", "No")
-                    .replaceAll("#5#", "All")
+                    .replaceAll("#5#", "No")
                     .replaceAll("#\"OBJECT_OWNER\"#", "\"" + dataSource.getUsername() + "\"");
             // ok if no exception is thrown
             jdbcTemplate.update(query);

--- a/sqldev/src/test/java/com/salvis/plscope/sqldev/test/ActionTest.java
+++ b/sqldev/src/test/java/com/salvis/plscope/sqldev/test/ActionTest.java
@@ -30,7 +30,10 @@ public class ActionTest extends AbstractJdbcTest{
                     .replaceAll("#0#", "ALL")
                     .replaceAll("#1#", "ALL")
                     .replaceAll("#2#", "Yes")
-                    .replaceAll("#3#", "Yes");
+                    .replaceAll("#3#", "Yes")
+                    .replaceAll("#4#", "Yes")
+                    .replaceAll("#5#", "All")
+                    .replaceAll("#\"OBJECT_OWNER\"#", "\"" + dataSource.getUsername() + "\"");
             // ok if no exception is thrown
             jdbcTemplate.update(query);
         }
@@ -42,7 +45,10 @@ public class ActionTest extends AbstractJdbcTest{
                     .replaceAll("#0#", "ALL")
                     .replaceAll("#1#", "ALL")
                     .replaceAll("#2#", "No")
-                    .replaceAll("#3#", "No");
+                    .replaceAll("#3#", "No")
+                    .replaceAll("#4#", "No")
+                    .replaceAll("#5#", "All")
+                    .replaceAll("#\"OBJECT_OWNER\"#", "\"" + dataSource.getUsername() + "\"");
             // ok if no exception is thrown
             jdbcTemplate.update(query);
         }

--- a/sqldev/src/test/java/com/salvis/plscope/sqldev/test/ReportTest.java
+++ b/sqldev/src/test/java/com/salvis/plscope/sqldev/test/ReportTest.java
@@ -28,7 +28,7 @@ public class ReportTest extends AbstractJdbcTest{
 
         @Test
         public void query122() {
-            var node = xmlTools.getNode(doc, "/displays/folder/display[name='Duplicate SQL Statements']/query[@minversion='12.2']/sql");
+            var node = xmlTools.getNode(doc, "/displays/folder/folder/display[name='Duplicate SQL Statements']/query[@minversion='12.2']/sql");
             var query = node.getTextContent().replaceAll(":[A-Z_]+", "null");
             var actual = jdbcTemplate.queryForList(query);
             var expected = jdbcTemplate.queryForList("""
@@ -45,7 +45,7 @@ public class ReportTest extends AbstractJdbcTest{
 
         @Test
         public void query122() {
-            var node = xmlTools.getNode(doc, "/displays/folder/display[name='UDF Calls in SQL Statements']/query[@minversion='12.2']/sql");
+            var node = xmlTools.getNode(doc, "/displays/folder/folder/display[name='UDF Calls in SQL Statements']/query[@minversion='12.2']/sql");
             var query = node.getTextContent().replaceAll(":[A-Z_]+", "null");
             var actual = jdbcTemplate.queryForList(query);
             var expected = jdbcTemplate.queryForList("""
@@ -69,7 +69,7 @@ public class ReportTest extends AbstractJdbcTest{
 
         @Test
         public void query122() {
-            var node = xmlTools.getNode(doc, "/displays/folder/display[name='CRUD Operations']/query[@minversion='12.2']/sql");
+            var node = xmlTools.getNode(doc, "/displays/folder/folder/display[name='CRUD Operations']/query[@minversion='12.2']/sql");
             var query = node.getTextContent().replaceAll(":[A-Z_]+", "null");
             var actual = jdbcTemplate.queryForList(query);
             var expected = jdbcTemplate.queryForList("""
@@ -92,7 +92,7 @@ public class ReportTest extends AbstractJdbcTest{
 
         @Test
         public void query122() {
-            var node = xmlTools.getNode(doc, "/displays/folder/display[name='Unused Local Identifiers']/query[@minversion='12.2']/sql");
+            var node = xmlTools.getNode(doc, "/displays/folder/folder/display[name='Unused Local Identifiers']/query[@minversion='12.2']/sql");
             var query = node.getTextContent().replaceAll(":[A-Z_]+", "null");
             var actual = jdbcTemplate.queryForList(query);
             var expected = jdbcTemplate.queryForList("""
@@ -106,7 +106,7 @@ public class ReportTest extends AbstractJdbcTest{
 
         @Test
         public void query111() {
-            var node = xmlTools.getNode(doc, "/displays/folder/display[name='Unused Local Identifiers']/query[@minversion='11.1']/sql");
+            var node = xmlTools.getNode(doc, "/displays/folder/folder/display[name='Unused Local Identifiers']/query[@minversion='11.1']/sql");
             var query = node.getTextContent().replaceAll(":[A-Z_]+", "null");
             var actual = jdbcTemplate.queryForList(query);
             var expected = jdbcTemplate.queryForList("""
@@ -143,7 +143,7 @@ public class ReportTest extends AbstractJdbcTest{
 
         @Test
         public void query111() {
-            var node = xmlTools.getNode(doc, "/displays/folder/display[name='PL/SQL Naming Conventions']/query[@minversion='11.1']/sql");
+            var node = xmlTools.getNode(doc, "/displays/folder/folder/display[name='PL/SQL Naming Conventions']/query[@minversion='11.1']/sql");
             var query = node.getTextContent()
                     .replaceAll(":LOCAL_VARIABLE_REGEX", "'^x_.*'")
                     .replaceAll(":[A-Z_]+", "null");

--- a/sqldev/src/test/resources/test.properties
+++ b/sqldev/src/test/resources/test.properties
@@ -4,5 +4,5 @@ port=1521
 service=odb.docker
 
 # oracle user credentials
-username=plscope
+username=PLSCOPE
 password=plscope


### PR DESCRIPTION
Hi Philipp,

Here's a new pull request, with 2 distinct changes to the SQL Dev extension:

1/ A new report, called "Synonyms with/wo PL/Scope", which lists synonyms and shows if they have been compiled with PL/Scope or not. 

That report requires DBA privileges (it selects from `dba_synonyms`, `dba_objects`, and `sys.plscope_identifier$`), which sets it apart from the other reports, which use `all_` views only. Therefore, I have created 2 sub-folders to make that point clear:

-   "Main reports": all prior reports are now in that sub-folder
-   "Other reports"; the new report is put in that sub-folder

The distinction as regards privileges requirements is mentioned in folder's tooltips.

(Remark: there doesn't seem to be any flexibility as regards ordering folders and reports: my initial plan was to put the new report aside in a new "DBA" sub-folder, leaving the other reports in the topmost folder as before. Meanwhile, because the new report is of lesser importance, I wanted that "DBA" sub-folder to appear _after_ the other reports, not prominently before them. But that didn't work: whatever I tried it came up first... So I gave up and created 2 sub-folders instead; "main" is alphabetically before "other", and that's the intended order, as far as I'm concerned.)

2/ A reworked "Compile with PL/Scope..." action, intended to be more "DBA-friendly":

-   The target of the action is the schema identified by `OBJECT_OWNER`, not `user`. This enables a user with DBA privileges to apply it to an arbitrary schema.
-   It uses `DBA_` views if available, and `ALL_` views as a fallback. Remark: SQL Developer does not substitute `DBA_` views for `ALL_` views automatically there, so we do it ourselves (at the cost of featuring a prompt for that in the action's dialog, but since that prompt is set automatically, it doesn't hurt too much, IMO).
-   Recompilation of public synonyms, and of private synonyms, are now 2 separate prompts.
-   Applying the action to an Oracle-maintained schema is disabled. This is to prevent "fresh" users having DBA rights from wreaking havoc in their Data Dictionary by trying it on, e.g. the SYS schema—because it would be so cool to have it compiled with PL/Scope—and get into trouble. Because the `ORACLE_MAINTAINED` column in the `all_users` view did not exist before 12.1, I had to resort to a static list (hopefully comprehensive) of known Oracle-maintained users.
-   A new method of recompilation is available, which preserves prior compilation settings—except `plscope_settings` of course. This method is selected as default. The original method (which recompiles types first, then the rest of the schema using `dbms_utility.compile_schema`) remains available as an option, but with a "!!! WARNING !!!" flag appended to the menu entry if heterogeneous compilation settings are found in the schema, and an additional safety check in the code: an ORA-20000 exception is raised if the schema contains modules with `plsql_ccflags` set, in order to prevent from clearing these inadvertently though recompilation with different session settings. Remark: the new method does not rely on `dbms_utility.compile_schema`; instead, it attempts to compute the dependency order, using a recursive query on `dba_dependencies`, then it issues `ALTER` statements. A clean and simple alternative would be to update the value of `plscope_settings` by calling `dbms_utility.invalidate` on all concerned objects, then recompile using `dbms_utility.compile_schema` with the `reuse_settings => true` argument. But I'd argue there's a reason for not using `dbms_utility.compile_schema` if we can dispense with it: it may break—and I've seen that on 11.2—if 2 users on the DB happen to call it at the very same time (MOS Doc ID 1568324.1), so I preferred a home-brewn recompilation routine here.
-   An option to "log" using `dbms_output` is available (off by default). It's not perfectly integrated to SQL Developer, because SQL Developer will not read from the output buffer automatically once the action completes; instead, the user has to arrange for SQL Developer to read from the buffer (`exec null;` in a SQL worksheet does it, provided that `serveroutput` is `on`, or that the Dbms Output pane is enabled for the user's session), so it's a bit inconvenient, but not difficult.
-   A (terse) help text is available.

Thanks & Regards,