### PR TITLE
Revised fix for issue #47

### DIFF
--- a/database/install.sql
+++ b/database/install.sql
@@ -84,6 +84,7 @@ show errors
 show errors
 @./utils/view/plscope_naming.sql
 show errors
+@./utils/view/plscope_naming-post.sql
 
 prompt ====================================================================
 prompt Grants

--- a/database/utils/view/plscope_naming-post.sql
+++ b/database/utils/view/plscope_naming-post.sql
@@ -1,0 +1,51 @@
+/*
+* Copyright 2017 Philipp Salvisberg <philipp.salvisberg@trivadis.com>
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+-- Post-creation actions on the plscope_naming view:
+--   1. Re-create the view, with the text of the view comment inlined
+--      after the initial "with" keyword
+--   2. Rewrite the view comment, in a lighter form without the "/*",
+--      "*", and "*/" markers
+declare
+   co_view_name   constant user_views.view_name %type := 'PLSCOPE_NAMING';
+   co_trim_chars  constant varchar2(2 char) := ' ' || chr(10);
+
+   l_view_src     long; -- NOSONAR: G-2510
+   l_view_text    clob;
+
+   l_comment_text varchar2(4000 byte);
+begin
+   select v.text into l_view_src -- NOSONAR: G-2510
+     from user_views v
+    where v.view_name = co_view_name;
+   l_view_text := l_view_src;    -- NOSONAR: G-2510
+
+   select c.comments into l_comment_text
+     from user_tab_comments c
+    where c.table_name = co_view_name
+      and c.table_type = 'VIEW';
+
+   execute immediate 'create or replace view ' || co_view_name || ' as '
+      || regexp_substr(l_view_text, '^with\s*$', 1, 1, 'm')
+      || rtrim(l_comment_text, co_trim_chars)
+      || regexp_replace(l_view_text, '^with\s*$', '', 1, 1, 'm');
+
+   execute immediate 'comment on table ' || co_view_name || ' is q''#'
+      || rtrim(ltrim(regexp_replace(l_comment_text, '^...?', '', 1, 0, 'm'),
+                     co_trim_chars), co_trim_chars)
+      || '#''';
+end;
+/

--- a/database/utils/view/plscope_naming.sql
+++ b/database/utils/view/plscope_naming.sql
@@ -13,37 +13,10 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+
+-- For usage notes, please see the comment statement below.
 create or replace view plscope_naming as
    with
-      --
-      -- You may configure regular expressions for every name check. 
-      -- Here's an example for overriding every attribute used in this view
-      -- to combine various naming conventions:
-      --
-      --    begin
-      --       plscope_context.set_attr('GLOBAL_VARIABLE_REGEX',       '^(g|m)_.*');
-      --       plscope_context.set_attr('LOCAL_RECORD_VARIABLE_REGEX', '^(r|l|v)_.*');
-      --       plscope_context.set_attr('LOCAL_ARRAY_VARIABLE_REGEX',  '^(t|l|v)_.*');
-      --       plscope_context.set_attr('LOCAL_OBJECT_VARIABLE_REGEX', '^(o|l|v)_.*');
-      --       plscope_context.set_attr('LOCAL_VARIABLE_REGEX',        '(^(l|v|c)_.*)|(^[ij]$)');
-      --       plscope_context.set_attr('CURSOR_REGEX',                '^(c|l)_.*');
-      --       plscope_context.set_attr('CURSOR_PARAMETER_REGEX',      '(^(p|in|out|io)_.*)|(.*_(in|out|io)$)');
-      --       plscope_context.set_attr('IN_PARAMETER_REGEX',          '(^(in|p)_.*)|(.*_in$)');
-      --       plscope_context.set_attr('OUT_PARAMETER_REGEX',         '(^(out|p)_.*)|(.*_out$)');
-      --       plscope_context.set_attr('IN_OUT_PARAMETER_REGEX',      '(^(io|p)_.*)|(.*_io$)');
-      --       plscope_context.set_attr('RECORD_REGEX',                '^(r|tp?)_.*');
-      --       plscope_context.set_attr('ARRAY_REGEX',                 '(^tp?_.*)|(^.*_(type?|l(ist)?|tab(type)?|t(able)?|arr(ay)?|ct|nt|ht)$)');
-      --       plscope_context.set_attr('EXCEPTION_REGEX',             '(^ex?_.*)|(.*_exc(eption)?$)');
-      --       plscope_context.set_attr('CONSTANT_REGEX',              '^(co?|gc?|m|l|k)_.*');
-      --       plscope_context.set_attr('SUBTYPE_REGEX',               '(^tp?_.*$)|(.*_type?$)');
-      --    end;
-      --
-      -- To restore default-settings call: 
-      --
-      --    begin
-      --       plscope_context.remove_all;
-      --    end;
-      --
       src as (
          select /*+ materialize */
                 owner,
@@ -485,3 +458,43 @@ create or replace view plscope_naming as
           text
      from checked
     where message is not null;
+
+
+-- Usage notes
+-- (Remark: wrapped into a PL/SQL anon. block due to
+--  issues with some versions of SQL*Plus otherwise.)
+begin
+   execute immediate q'#
+      comment on table plscope_naming is q'<
+/*
+ * You may configure regular expressions for every name check. 
+ * Here's an example for overriding every attribute used in this view
+ * to combine various naming conventions:
+ *
+      begin
+         plscope_context.set_attr('GLOBAL_VARIABLE_REGEX',       '^(g|m)_.*');
+         plscope_context.set_attr('LOCAL_RECORD_VARIABLE_REGEX', '^(r|l|v)_.*');
+         plscope_context.set_attr('LOCAL_ARRAY_VARIABLE_REGEX',  '^(t|l|v)_.*');
+         plscope_context.set_attr('LOCAL_OBJECT_VARIABLE_REGEX', '^(o|l|v)_.*');
+         plscope_context.set_attr('LOCAL_VARIABLE_REGEX',        '(^(l|v|c)_.*)|(^[ij]$)');
+         plscope_context.set_attr('CURSOR_REGEX',                '^(c|l)_.*');
+         plscope_context.set_attr('CURSOR_PARAMETER_REGEX',      '(^(p|in|out|io)_.*)|(.*_(in|out|io)$)');
+         plscope_context.set_attr('IN_PARAMETER_REGEX',          '(^(in|p)_.*)|(.*_in$)');
+         plscope_context.set_attr('OUT_PARAMETER_REGEX',         '(^(out|p)_.*)|(.*_out$)');
+         plscope_context.set_attr('IN_OUT_PARAMETER_REGEX',      '(^(io|p)_.*)|(.*_io$)');
+         plscope_context.set_attr('RECORD_REGEX',                '^(r|tp?)_.*');
+         plscope_context.set_attr('ARRAY_REGEX',                 '(^tp?_.*)|(^.*_(type?|l(ist)?|tab(type)?|t(able)?|arr(ay)?|ct|nt|ht)$)');
+         plscope_context.set_attr('EXCEPTION_REGEX',             '(^ex?_.*)|(.*_exc(eption)?$)');
+         plscope_context.set_attr('CONSTANT_REGEX',              '^(co?|gc?|m|l|k)_.*');
+         plscope_context.set_attr('SUBTYPE_REGEX',               '(^tp?_.*$)|(.*_type?$)');
+      end;
+ *
+ * To restore default settings, call: 
+ *
+      begin
+         plscope_context.remove_all;
+      end;
+ */
+>'#';
+end;
+/


### PR DESCRIPTION
The new fix consists of the following:

1.   Initially, the `plscope_naming` view is created _without_ the comments that confuses SQL\*Plus
2.   Then we add these comments by creating a regular comment on the view. That's where they belong! (Too bad comments on views are so poorly supported in SQLcl / SQL Developer as of now. :confused:)
      Remark: the `COMMENT` statement must be wrapped into a PL/SQL anonymous block due to SQL\*Plus limitations.
3.   Finally, another PL/SQL anonymous block is used to inject the comment text into the view, where it stood originally, after the `with` keyword.

Regards,