### PR TITLE
plscope_tab/col_usage: minor fixes/enh (+ corresp. changes to SQL Dev viewers/reports)

### DIFF
--- a/database/test/package/test_dd_util.pkb
+++ b/database/test/package/test_dd_util.pkb
@@ -1,19 +1,51 @@
 create or replace package body test_dd_util is
 
+   -- Forward decl.
+   procedure wrap_dyn_exec(in_stmt in varchar2);
+
    --
    -- setup
    --
    procedure setup is
    begin
-      execute immediate q'[ -- NOSONAR: G-6010
+      wrap_dyn_exec(q'[
          create or replace procedure p1 is
          begin
             null;
          end;
-      ]';
-      execute immediate 'create or replace synonym s1 for p1'; -- NOSONAR: G-6010
+      ]');
+
+      wrap_dyn_exec(q'[
+         create or replace view sample_vw1 as
+            with
+               cte(n, m2, m3) as (
+                  select level, mod(level, 2), mod(level, 3) from dual connect by level <= 10
+               )
+            select *
+              from cte
+             pivot ( listagg(to_char(n), ', ') within group (order by n) as lst 
+                     for m2 in (
+                        0 as even,
+                        1 as odd
+                     )
+                   )
+      ]');
+
+      wrap_dyn_exec('create or replace synonym s1 for p1');
+      wrap_dyn_exec('create or replace synonym s2 for s1');
+      wrap_dyn_exec('create or replace synonym s3 for s2');
+
+      wrap_dyn_exec('create or replace synonym syn_loop1 for p1');
+      wrap_dyn_exec('create or replace synonym syn_loop2 for syn_loop1');
+      wrap_dyn_exec('create or replace synonym syn_loop3 for syn_loop2');
+      wrap_dyn_exec('create or replace synonym syn_loop1 for syn_loop3');
+      
+      wrap_dyn_exec('create table to_be_dropped_t1 (c1 number)');
+      wrap_dyn_exec('create or replace synonym syn_nonexistent for to_be_dropped_t1');
+      wrap_dyn_exec('drop table to_be_dropped_t1 purge');
+
       -- issue 31: fix ORA-6550 that occurs from time to time while querying dba_synonyms
-      ut_runner.rebuild_annotation_cache(user);
+      ut_runner.rebuild_annotation_cache($$PLSQL_UNIT_OWNER);
    end setup;
    
    --
@@ -21,8 +53,15 @@ create or replace package body test_dd_util is
    --
    procedure teardown is
    begin
-      execute immediate 'drop synonym s1';   -- NOSONAR: G-6010
-      execute immediate 'drop procedure P1'; -- NOSONAR: G-6010
+      wrap_dyn_exec('drop view sample_vw1');
+      wrap_dyn_exec('drop synonym syn_nonexistent');
+      wrap_dyn_exec('drop synonym syn_loop3');
+      wrap_dyn_exec('drop synonym syn_loop2');
+      wrap_dyn_exec('drop synonym syn_loop1');
+      wrap_dyn_exec('drop synonym s3');
+      wrap_dyn_exec('drop synonym s2');
+      wrap_dyn_exec('drop synonym s1');
+      wrap_dyn_exec('drop procedure p1');
    end teardown;
 
    --
@@ -31,22 +70,54 @@ create or replace package body test_dd_util is
    procedure test_resolve_synonym is
       o_input  obj_type;
       o_actual obj_type;
+      l_current_schema user_users.username%type := sys_context('USERENV', 'CURRENT_SCHEMA');
    begin
       -- resolve
       o_input  := obj_type(null, null, 'S1');
-      o_actual := dd_util.resolve_synonym(in_parse_user => user, in_obj => o_input);
-      ut.expect(o_actual.owner).to_equal(user);
+      o_actual := dd_util.resolve_synonym(in_parse_user => l_current_schema, in_obj => o_input);
+      ut.expect(o_actual.owner).to_equal(l_current_schema);
       ut.expect(o_actual.object_type).to_equal('PROCEDURE');
       ut.expect(o_actual.object_name).to_equal('P1');
+      
+      -- resolve chain of synonyms
+      o_input  := obj_type(null, null, 'S3');
+      o_actual := dd_util.resolve_synonym(in_parse_user => l_current_schema, in_obj => o_input);
+      ut.expect(o_actual.owner).to_equal(l_current_schema);
+      ut.expect(o_actual.object_type).to_equal('PROCEDURE');
+      ut.expect(o_actual.object_name).to_equal('P1');
+      
+      -- shallow resolution (1st-level only)
+      o_input  := obj_type(null, null, 'S3');
+      o_actual := dd_util.resolve_synonym(in_parse_user => l_current_schema, 
+         in_obj => o_input, in_in_depth => 0);
+      ut.expect(o_actual.owner).to_equal(l_current_schema);
+      ut.expect(o_actual.object_type).to_equal('SYNONYM');
+      ut.expect(o_actual.object_name).to_equal('S2');
+      
+      -- failed resolve (synonym loop)
+      o_input  := obj_type(null, null, 'SYN_LOOP3');
+      o_actual := dd_util.resolve_synonym(in_parse_user => l_current_schema, in_obj => o_input);
+      ut.expect(o_actual.owner).to_(be_null);
+      ut.expect(o_actual.object_type).to_(be_null);
+      ut.expect(o_actual.object_name).to_(be_null);
+      
+      -- failed resolve (synonym of non-existent)
+      o_input  := obj_type(null, null, 'SYN_NONEXISTENT');
+      o_actual := dd_util.resolve_synonym(in_parse_user => l_current_schema, in_obj => o_input);
+      ut.expect(o_actual.owner).to_(be_null);
+      ut.expect(o_actual.object_type).to_(be_null);
+      ut.expect(o_actual.object_name).to_(be_null);
+      
       -- no resolve
       o_input  := obj_type(null, null, 'P1');
-      o_actual := dd_util.resolve_synonym(in_parse_user => user, in_obj => o_input);
-      ut.expect(o_actual.owner).to_equal(user);
+      o_actual := dd_util.resolve_synonym(in_parse_user => l_current_schema, in_obj => o_input);
+      ut.expect(o_actual.owner).to_equal(l_current_schema);
       ut.expect(o_actual.object_type).to_equal('PROCEDURE');
       ut.expect(o_actual.object_name).to_equal('P1');
+      
       -- unknown object
       o_input  := obj_type(null, null, 'X1');
-      o_actual := dd_util.resolve_synonym(in_parse_user => user, in_obj => o_input);
+      o_actual := dd_util.resolve_synonym(in_parse_user => l_current_schema, in_obj => o_input);
       ut.expect(o_actual.owner).to_(be_null);
       ut.expect(o_actual.object_type).to_(be_null);
       ut.expect(o_actual.object_name).to_(be_null);
@@ -58,22 +129,23 @@ create or replace package body test_dd_util is
    procedure test_get_object is
       o_input  obj_type;
       o_actual obj_type;
+      l_current_schema user_users.username%type := sys_context('USERENV', 'CURRENT_SCHEMA');
    begin
       -- synonym
       o_input  := obj_type(null, null, 'S1');
-      o_actual := dd_util.get_object(in_parse_user => user, in_obj => o_input);
-      ut.expect(o_actual.owner).to_(equal(user));
+      o_actual := dd_util.get_object(in_parse_user => l_current_schema, in_obj => o_input);
+      ut.expect(o_actual.owner).to_(equal(l_current_schema));
       ut.expect(o_actual.object_type).to_(equal('SYNONYM'));
       ut.expect(o_actual.object_name).to_(equal('S1'));
       -- procedure
       o_input  := obj_type(null, null, 'P1');
-      o_actual := dd_util.get_object(in_parse_user => user, in_obj => o_input);
-      ut.expect(o_actual.owner).to_(equal(user));
+      o_actual := dd_util.get_object(in_parse_user => l_current_schema, in_obj => o_input);
+      ut.expect(o_actual.owner).to_(equal(l_current_schema));
       ut.expect(o_actual.object_type).to_(equal('PROCEDURE'));
       ut.expect(o_actual.object_name).to_(equal('P1'));
       -- unknown object
       o_input  := obj_type(null, null, 'X1');
-      o_actual := dd_util.get_object(in_parse_user => user, in_obj => o_input);
+      o_actual := dd_util.get_object(in_parse_user => l_current_schema, in_obj => o_input);
       ut.expect(o_actual.owner).to_(be_null);
       ut.expect(o_actual.object_type).to_(be_null);
       ut.expect(o_actual.object_name).to_(be_null);
@@ -86,6 +158,7 @@ create or replace package body test_dd_util is
       t_input    t_obj_type;
       t_actual   t_obj_type;
       t_expected t_obj_type;
+      l_current_schema user_users.username%type := sys_context('USERENV', 'CURRENT_SCHEMA');
    begin
       t_input    := t_obj_type(
                        obj_type(null, null, 'P1'),
@@ -94,10 +167,10 @@ create or replace package body test_dd_util is
                        obj_type(null, 'SYNONYM', 'S1') -- duplicate
                     );
       t_expected := t_obj_type(
-                       obj_type(user, 'PROCEDURE', 'P1'),
-                       obj_type(user, 'SYNONYM', 'S1')
+                       obj_type(l_current_schema, 'PROCEDURE', 'P1'),
+                       obj_type(l_current_schema, 'SYNONYM', 'S1')
                     );
-      t_actual   := dd_util.get_objects(in_parse_user => user, in_t_obj => t_input);
+      t_actual   := dd_util.get_objects(in_parse_user => l_current_schema, in_t_obj => t_input);
       ut.expect(t_actual.count).to_equal(2);
       ut.expect(sys.anydata.convertcollection(t_actual)).to_equal(sys.anydata.convertcollection(t_expected)).unordered;
    end test_get_objects;
@@ -107,18 +180,19 @@ create or replace package body test_dd_util is
    --
    procedure test_get_column_id is
       l_actual integer;
+      l_current_schema user_users.username%type := sys_context('USERENV', 'CURRENT_SCHEMA');
    begin
       -- existing column
       l_actual := dd_util.get_column_id(
-                     in_owner       => user,
-                     in_object_name => 'PLSCOPE_IDENTIFIERS',
-                     in_column_name => 'LINE'
+                     in_owner       => l_current_schema,
+                     in_object_name => 'SAMPLE_VW1',
+                     in_column_name => 'EVEN_LST'
                   );
-      ut.expect(l_actual).to_equal(4);
+      ut.expect(l_actual).to_equal(2);
       -- non-existing column
       l_actual := dd_util.get_column_id(
-                     in_owner       => user,
-                     in_object_name => 'PLSCOPE_IDENTIFIERS',
+                     in_owner       => l_current_schema,
+                     in_object_name => 'SAMPLE_VW1',
                      in_column_name => 'XYZ'
                   );
       ut.expect(l_actual).to_(be_null);
@@ -130,16 +204,25 @@ create or replace package body test_dd_util is
    procedure test_get_view_source is
       o_input  obj_type;
       l_actual clob;
+      l_current_schema user_users.username%type := sys_context('USERENV', 'CURRENT_SCHEMA');
    begin
       -- fully qualified
-      o_input  := obj_type(user, 'VIEW', 'PLSCOPE_IDENTIFIERS');
+      o_input  := obj_type(l_current_schema, 'VIEW', 'SAMPLE_VW1');
       l_actual := dd_util.get_view_source(o_input);
       ut.expect(l_actual).to_match(a_pattern => '^(WITH)(.+)$', a_modifiers => 'ni');
       -- not fully qualified
-      o_input  := obj_type(null, 'VIEW', 'PLSCOPE_IDENTIFIERS');
+      o_input  := obj_type(null, 'VIEW', 'SAMPLE_VW1');
       l_actual := dd_util.get_view_source(o_input);
       ut.expect(l_actual).to_(be_null);
    end test_get_view_source;
+
+   --
+   -- wrap_dyn_exec: wrapper for execute immediate
+   --
+   procedure wrap_dyn_exec(in_stmt in varchar2) is
+   begin
+      execute immediate in_stmt;
+   end wrap_dyn_exec;
 
 end test_dd_util;
 /

--- a/database/test/package/test_parse_util.pkb
+++ b/database/test/package/test_parse_util.pkb
@@ -1,5 +1,7 @@
 create or replace package body test_parse_util is
 
+   co_plsql_unit_owner constant user_users.username%type := $$PLSQL_UNIT_OWNER;
+
    --
    -- test_parse_query
    --
@@ -25,7 +27,7 @@ create or replace package body test_parse_util is
   </FROM>
 </QUERY>
 ]';
-      l_actual   := parse_util.parse_query(in_parse_user => user, in_query => 'select ename from emp');
+      l_actual   := parse_util.parse_query(in_parse_user => co_plsql_unit_owner, in_query => 'select ename from emp');
       ut.expect(l_actual.getclobval()).to_equal(l_expected);
    end test_parse_query;
 
@@ -39,7 +41,7 @@ create or replace package body test_parse_util is
       -- single table insert
       t_expected := t_obj_type(obj_type(null, null, 'DEPT'));
       t_actual   := parse_util.get_insert_targets(
-                       in_parse_user => user,
+                       in_parse_user => co_plsql_unit_owner,
                        in_sql        => q'[
                           insert into dept values (50, 'TRAINING', 'ZURICH')
                        ]'
@@ -51,7 +53,7 @@ create or replace package body test_parse_util is
                        obj_type(null, null, 'DEPT')
                     );
       t_actual   := parse_util.get_insert_targets(
-                       in_parse_user => user,
+                       in_parse_user => co_plsql_unit_owner,
                        in_sql        => q'[
                            insert all
                               when rec_type = 'EMP' then
@@ -148,7 +150,7 @@ create or replace package body test_parse_util is
       l_expected   clob;
    begin
       l_parse_tree := parse_util.parse_query(
-                         in_parse_user => user,
+                         in_parse_user => co_plsql_unit_owner,
                          in_query      => q'[
                             select /*+ordered */
                                    d.deptno, d.dname, sum(e.sal + nvl(e.comm, 0)) as sal

--- a/database/test/package/test_plscope_identifiers.pks
+++ b/database/test/package/test_plscope_identifiers.pks
@@ -1,7 +1,13 @@
-create or replace package test_plscope_identifiers is
+create or replace package test_plscope_identifiers authid current_user is
 
    --%suite
    --%suitepath(plscope.test)
+
+   --%beforeeach
+   procedure set_context;
+
+   --%aftereach
+   procedure clear_context;
 
    --%test
    procedure user_identifiers;

--- a/database/utils/package/dd_util.pks
+++ b/database/utils/package/dd_util.pks
@@ -27,23 +27,27 @@ create or replace package dd_util is
    *
    * @param in_parse_user parsing user
    * @param in_obj partially qualified object (synonym)
+   * @param in_in_depth resolve synonym chains in depth? 1=true (default), 0=false
    * @returns fully qualifed object
    */
    function resolve_synonym(
       in_parse_user in varchar2,
-      in_obj        in obj_type
+      in_obj        in obj_type,
+      in_in_depth   in number default 1
    ) return obj_type;
 
    /**
    * Gets the fully qualified object.
    *
-   * @param in_parse_user parsing user
+   * @param in_parse_user parsing schema
    * @param in_obj partially qualified object
+   * @param in_namespace the namespace where the object must be found (default: 1)
    * @returns fully qualifed object
    */
    function get_object(
       in_parse_user in varchar2,
-      in_obj        in obj_type
+      in_obj        in obj_type,
+      in_namespace  in number default 1
    ) return obj_type;
    
    /**
@@ -53,11 +57,13 @@ create or replace package dd_util is
    *
    * @param in_parse_user parsing user
    * @param in_t_obj list of partially qualified objects
+   * @param in_namespace the namespace where the objects must be found (default: 1)
    * @returns table of objects
    */
    function get_objects(
       in_parse_user in varchar2,
-      in_t_obj      in t_obj_type
+      in_t_obj      in t_obj_type,
+      in_namespace  in number default 1
    ) return t_obj_type;
    
    /**

--- a/database/utils/package/lineage_util.pkb
+++ b/database/utils/package/lineage_util.pkb
@@ -157,7 +157,7 @@ create or replace package body lineage_util is
                   select value(p) as col
                     from table(
                             lineage_util.get_dep_cols_from_query(
-                               in_parse_user => in_owner,
+                               in_parse_user => o_obj.owner,
                                in_query      => l_query,
                                in_column_pos => l_column_id,
                                in_recursive  => in_recursive

--- a/database/utils/view/plscope_tab_usage.sql
+++ b/database/utils/view/plscope_tab_usage.sql
@@ -167,6 +167,8 @@ create or replace view plscope_tab_usage as
           on dep.owner = ids.ref_owner
          and dep.type = ids.ref_object_type
          and dep.name = ids.ref_object_name
+         and (dep.ref_type <> 'SYNONYM'     -- ignore synonyms unless directly referenced
+                or dep.path_len = 0)
          and dep.base_obj_type is not null  -- drop syn. refs not leading to tables/views
         left join sys.dba_statements refs   -- NOSONAR: avoid public synonym
           on refs.signature = ids.parent_statement_signature;

--- a/database/utils/view/plscope_tab_usage.sql
+++ b/database/utils/view/plscope_tab_usage.sql
@@ -16,7 +16,7 @@
 
 create or replace view plscope_tab_usage as
    with
-      identifiers as (
+      table_usage_ids as (
          select /*+ materialize */
                 ids.owner,
                 ids.object_type,
@@ -54,7 +54,7 @@ create or replace view plscope_tab_usage as
                 ids.ref_object_type,
                 ids.ref_object_name,
                 0
-           from identifiers ids
+           from table_usage_ids ids
           where ids.ref_object_type in ('VIEW', 'TABLE', 'SYNONYM')
           union all
          -- indirect dependencies
@@ -162,7 +162,7 @@ create or replace view plscope_tab_usage as
              ids.text,
              dep.is_base_object,
              dep.path_len
-        from identifiers ids
+        from table_usage_ids ids
         join dep_trans_closure dep
           on dep.owner = ids.ref_owner
          and dep.type = ids.ref_object_type

--- a/database/utils/view/plscope_tab_usage.sql
+++ b/database/utils/view/plscope_tab_usage.sql
@@ -16,136 +16,157 @@
 
 create or replace view plscope_tab_usage as
    with
-      dep as (
-         select owner as owner,
-                'TABLE' as type,
-                table_name as name,
-                null as referenced_owner,
-                null as referenced_type,
-                null as referenced_name
-           from sys.dba_tables -- NOSONAR: avoid public synonym
-         union all
-         select owner,
-                type,
-                name,
-                referenced_owner,
-                referenced_type,
-                referenced_name
-           from sys.dba_dependencies -- NOSONAR: avoid public synonym
-          where type in ('VIEW', 'MATERIALIZED VIEW', 'SYNONYM')
-      ),
-      -- recursive with clause to calculate ref_object_type_path
-      dep_graph_base (
-         owner,
-         object_type,
-         object_name,
-         ref_owner,
-         ref_object_type,
-         ref_object_name,
-         ref_object_type_path,
-         path_len
-      ) as (
-         select owner,
-                type,
-                name,
-                owner as ref_owner,
-                type as ref_object_type,
-                name as ref_object_name,
-                '/' || type as ref_object_type_path,
-                1 as path_len
-           from dep
-         union all
-         select dep.owner,
-                dep.type,
-                dep.name,
-                dep_graph_base.ref_owner,
-                dep_graph_base.ref_object_type,
-                dep_graph_base.ref_object_name,
-                case
-                   when lengthb(dep_graph_base.ref_object_type_path) + lengthb('/') + lengthb(dep.type) <= 4000 then
-                      dep_graph_base.ref_object_type_path
-                      || '/'
-                      || dep.type
-                   else
-                      -- prevent ref_object_type_path from overflowing: keep the first 3 elements, then
-                      -- remove enough elements to accomodate "..." + "/" + the tail end
-                      regexp_substr(dep_graph_base.ref_object_type_path, '^(/([^/]+/){3})')
-                      || '...'
-                      || regexp_replace(
-                         substr(dep_graph_base.ref_object_type_path, instr(dep_graph_base.ref_object_type_path, '/', 1, 4) + 1
-                            + lengthb('.../') + lengthb(dep.type)),
-                         '^[^/]*')
-                      || '/'
-                      || dep.type
-                end as ref_object_type_path,
-                dep_graph_base.path_len + 1 as path_len
-           from dep_graph_base
-           join dep
-             on dep_graph_base.owner = dep.referenced_owner
-            and dep_graph_base.object_type = dep.referenced_type
-            and dep_graph_base.object_name = dep.referenced_name
-      ) cycle owner, object_type, object_name set is_cycle to 'Y' default 'N',
-      -- remove duplicate rows
-      dep_graph as (
-         select distinct
-                owner,
-                object_type,
-                object_name,
-                ref_owner,
-                ref_object_type,
-                ref_object_name,
-                ref_object_type_path,
-                path_len
-           from dep_graph_base
-      ),
-      tab_usage as (
-         select /*+use_hash(ids) use_hash(dep_graph) use_hash(refs)*/
+      identifiers as (
+         select /*+ materialize */
                 ids.owner,
                 ids.object_type,
                 ids.object_name,
+                ids.procedure_name,
+                ids.usage,
                 ids.line,
                 ids.col,
-                ids.procedure_name,
-                case
-                   when refs.type is not null then
-                      refs.type
-                   else
-                      ids.usage
-                end as operation,
-                dep_graph.ref_owner,
-                dep_graph.ref_object_type,
-                dep_graph.ref_object_name,
-                case
-                   when dep_graph.path_len = 1 then
-                      'YES'
-                   else
-                      'NO'
-                end as direct_dependency,
-                dep_graph.ref_object_type_path,
-                lead(dep_graph.ref_object_type_path) over (
-                   order by ids.owner, ids.object_type, ids.object_name, ids.line, ids.col, dep_graph.path_len
-                ) as next_ref_object_type_path,
+                ids.ref_owner,
+                ids.ref_object_type,
+                ids.ref_object_name,
+                ids.parent_statement_signature,
                 ids.text
            from plscope_identifiers ids
-           join dep_graph
-             on dep_graph.owner = ids.ref_owner
-            and dep_graph.object_type = ids.ref_object_type
-            and dep_graph.object_name = ids.ref_object_name
-           left join sys.dba_statements refs -- NOSONAR: avoid public synonym
-             on refs.signature = parent_statement_signature
           where ids.type in ('VIEW', 'TABLE', 'SYNONYM')
+      ),
+      -- direct and indirect dependencies; path_len = 0 for direct dependencies, 
+      -- otherwise the length of the dependency chain, i.e. level - 1; cycles are
+      -- possible here (with help from synonyms) so we need to detect them 
+      dep_chains (
+         owner,
+         type,
+         name,
+         ref_owner,
+         ref_type,
+         ref_name,
+         path_len
+      ) as (
+         -- direct dependencies
+         select distinct
+                ids.ref_owner,
+                ids.ref_object_type,
+                ids.ref_object_name,
+                ids.ref_owner,
+                ids.ref_object_type,
+                ids.ref_object_name,
+                0
+           from identifiers ids
+          where ids.ref_object_type in ('VIEW', 'TABLE', 'SYNONYM')
+          union all
+         -- indirect dependencies
+         select /*+ no_merge(dep) */ 
+                par.owner,
+                par.type,
+                par.name,
+                dep.referenced_owner,
+                dep.referenced_type,
+                dep.referenced_name,
+                par.path_len + 1
+           from dep_chains par
+           join sys.dba_dependencies dep  -- NOSONAR: avoid public synonym
+             on par.ref_owner = dep.owner
+            and par.ref_type = dep.type
+            and par.ref_name = dep.name
+            and dep.referenced_type in (  -- list of referenced types of interest
+                   'VIEW', 
+                   'TABLE', 
+                   'SYNONYM',
+                   'MATERIALIZED VIEW'    -- does MATERIALIZED VIEW belong here?
+                )
       )
-   select owner,
-          object_type,
-          object_name,
-          line,
-          col,
-          procedure_name,
-          operation,
-          ref_owner,
-          ref_object_type,
-          ref_object_name,
-          direct_dependency,
-          text
-     from tab_usage
-    where (ref_object_type != 'SYNONYM' or next_ref_object_type_path in ('/VIEW/SYNONYM', '/TABLE/SYNONYM'));
+      cycle ref_owner, ref_type, ref_name set is_cycle to 'Y' default 'N',
+      -- eliminate duplicate dependencies, keeping the minimum path_len; add the 
+      -- base_object_type column, which is the type of the first object (if any)
+      -- which is not a synonym, in case we're going down a chain of synonyms;
+      -- the is_base_object flag is set to 'YES' for that object, otherwise null
+      dep_trans_closure as (
+         select owner,
+                type,
+                name,
+                ref_owner,
+                ref_type,
+                ref_name,
+                min(path_len)  as path_len,
+                nullif(                            -- @formatter:off
+                   min(ref_type)
+                   keep (
+                      dense_rank first
+                      order by 
+                         case
+                            when ref_type = 'SYNONYM' then
+                               null
+                            else
+                               min(path_len)
+                         end asc nulls last,
+                         min(path_len)
+                   )
+                   over (
+                      partition by owner, type, name
+                   ),
+                   'SYNONYM'
+                )  as base_obj_type,               -- @formatter:on
+                case                               -- @formatter:off
+                   -- remark: disregarding the case when there are only SYNONYMs in the 
+                   -- dependency chain: such chains are filtered out in the main query
+                   when min(path_len) = min(min(path_len))
+                         keep (
+                            dense_rank first
+                            order by 
+                               case
+                                  when ref_type = 'SYNONYM' then
+                                     null
+                                  else
+                                     min(path_len)
+                               end asc nulls last,
+                               min(path_len)
+                         )
+                         over (
+                            partition by owner, type, name
+                         ) 
+                   then
+                      cast('YES' as varchar2(3 char))
+                end  as is_base_object             -- @formatter:on
+           from dep_chains
+          group by owner,
+                type,
+                name,
+                ref_owner,
+                ref_type,
+                ref_name
+      )
+      select ids.owner,
+             ids.object_type,
+             ids.object_name,
+             ids.line,
+             ids.col,
+             ids.procedure_name,
+             case
+                when refs.type is not null then
+                   refs.type
+                else
+                   ids.usage
+             end as operation,
+             dep.ref_owner,
+             dep.ref_type  as ref_object_type,
+             dep.ref_name  as ref_object_name,
+             case
+                when dep.path_len = 0 then
+                   'YES'
+                else
+                   'NO'
+             end as direct_dependency,
+             ids.text,
+             dep.is_base_object,
+             dep.path_len
+        from identifiers ids
+        join dep_trans_closure dep
+          on dep.owner = ids.ref_owner
+         and dep.type = ids.ref_object_type
+         and dep.name = ids.ref_object_name
+         and dep.base_obj_type is not null  -- drop syn. refs not leading to tables/views
+        left join sys.dba_statements refs   -- NOSONAR: avoid public synonym
+          on refs.signature = ids.parent_statement_signature;

--- a/sqldev/src/main/resources/com/salvis/plscope/sqldev/editor/plscope-utils-viewers.xml
+++ b/sqldev/src/main/resources/com/salvis/plscope/sqldev/editor/plscope-utils-viewers.xml
@@ -181,8 +181,7 @@ with
    ),
    -- recursive with clause to extend the list of identifiers with the columns
    -- procedure_name, procedure_scope, name_path, path_len (level), procedure_signature,
-   -- parent_statement_type, parent_statement_signature, parent_statement_path_len,
-   -- is_def_child_of_decl
+   -- parent_statement_type, parent_statement_signature, parent_statement_path_len
    tree (
       owner,
       object_type,
@@ -205,7 +204,6 @@ with
       parent_statement_type,
       parent_statement_signature,
       parent_statement_path_len,
-      is_def_child_of_decl,
       origin_con_id
    ) as (
       select owner,
@@ -238,7 +236,6 @@ with
              cast(null as varchar2(18 char)) as parent_statement_type,
              cast(null as varchar2(32 char)) as parent_statement_signature,
              cast(null as number) as parent_statement_path_len,
-             cast(null as varchar2(3 char)) as is_def_child_of_decl,
              origin_con_id
         from ids
        where usage_context_id = 0  -- top-level identifiers
@@ -333,19 +330,6 @@ with
                 else
                    tree.parent_statement_path_len
              end as parent_statement_path_len,
-             case
-                when ids.type in ('PROCEDURE', 'FUNCTION')
-                   and ids.usage = 'DEFINITION'
-                then
-                   case
-                      when tree.usage = 'DECLARATION'
-                         and ids.signature = tree.signature
-                      then
-                         'YES'
-                      else
-                         'NO'
-                   end
-             end as is_def_child_of_decl,
              ids.origin_con_id
         from tree
         join ids
@@ -354,43 +338,22 @@ with
          and tree.object_name = ids.object_name
          and tree.usage_id = ids.usage_context_id
    ) cycle owner, object_type, object_name, usage_id set is_cycle to 'Y' default 'N',
-   -- add the columns name_usage, is_new_proc to the list of identifiers
+   -- add the name_usage column to the list of identifiers
    tree_plus as (
       select tree.*,                                                 -- @formatter:off
              case
-                   when tree.usage = 'SQL_ID' then
-                      tree.type || ' statement (sql_id: ' || tree.name || ')'
-                   when tree.usage = 'SQL_STMT' then
-                      tree.type || ' statement'
-                   else
-                      tree.name || ' (' || lower(tree.type) || ' ' || lower(tree.usage) || ')'
-                end as name_usage,                                      -- @formatter:on
-             case
-                when type in ('PROCEDURE', 'FUNCTION')
-                   and usage = 'DEFINITION'
-                   and nvl(
-                      lag(
-                         procedure_signature,
-                         case is_def_child_of_decl
-                            when 'YES' then
-                               2
-                            else
-                               1
-                         end
-                      ) over (
-                         partition by tree.owner, tree.object_type, tree.object_name
-                         order by usage_id asc
-                      ),
-                      '----'
-                   ) != procedure_signature
-                then
-                   'YES'
-             end as is_new_proc
+                when tree.usage = 'SQL_ID' then
+                   tree.type || ' statement (sql_id: ' || tree.name || ')'
+                when tree.usage = 'SQL_STMT' then
+                   tree.type || ' statement'
+                else
+                   tree.name || ' (' || lower(tree.type) || ' ' || lower(tree.usage) || ')'
+             end as name_usage                                       -- @formatter:on
         from tree
    ),
    plscope_identifiers as (
-      -- add indent to column name_usage, fix column usage and adds the columns text, is_used,
-      -- proc_ends_before_line, proc_ends_before_col, ref_line, ref_col to the list of identifiers
+      -- add indent to column name_usage, fix column usage, and add the text, is_used,
+      -- ref_line, and ref_col columns to the list of identifiers
       select tree.owner,
              tree.object_type,
              tree.object_name,
@@ -461,46 +424,6 @@ with
              tree.usage_context_id,
              tree.is_fixed_context_id,
              tree.procedure_signature,
-             --tree.is_def_child_of_decl,    --uncomment if needed for debugging
-             --tree.is_new_proc,             --uncomment if needed for debugging
-             case
-                when tree.is_new_proc = 'YES' then
-                   coalesce(
-                      first_value(
-                         case
-                            when tree.is_new_proc = 'YES'
-                               or tree.usage_context_id = 1
-                            then
-                               tree.line
-                         end
-                      ) ignore nulls over (
-                         partition by tree.owner, tree.object_type, tree.object_name
-                         order by tree.usage_id
-                         rows between 1 following and unbounded following
-                      ),
-                      max(tree.line) over (
-                            partition by tree.owner, tree.object_type, tree.object_name
-                      ) + 1
-                   )
-             end as proc_ends_before_line,
-             case
-                when tree.is_new_proc = 'YES' then
-                   nvl(
-                      first_value(
-                         case
-                            when tree.is_new_proc = 'YES'
-                               or tree.usage_context_id = 1
-                            then
-                               tree.col
-                         end
-                      ) ignore nulls over (
-                         partition by tree.owner, tree.object_type, tree.object_name
-                         order by tree.usage_id
-                         rows between 1 following and unbounded following
-                      ),
-                      1
-                   )
-             end as proc_ends_before_col,
              refs.line as ref_line,         -- decl_line
              refs.col as ref_col,           -- decl_col
              tree.origin_con_id
@@ -677,8 +600,7 @@ with
    ),
    -- recursive with clause to extend the list of identifiers with the columns
    -- procedure_name, procedure_scope, name_path, path_len (level), procedure_signature,
-   -- parent_statement_type, parent_statement_signature, parent_statement_path_len,
-   -- is_def_child_of_decl
+   -- parent_statement_type, parent_statement_signature, parent_statement_path_len
    tree (
       owner,
       object_type,
@@ -701,7 +623,6 @@ with
       parent_statement_type,
       parent_statement_signature,
       parent_statement_path_len,
-      is_def_child_of_decl,
       origin_con_id
    ) as (
       select owner,
@@ -734,7 +655,6 @@ with
              cast(null as varchar2(18 char)) as parent_statement_type,
              cast(null as varchar2(32 char)) as parent_statement_signature,
              cast(null as number) as parent_statement_path_len,
-             cast(null as varchar2(3 char)) as is_def_child_of_decl,
              origin_con_id
         from ids
        where usage_context_id = 0  -- top-level identifiers
@@ -829,19 +749,6 @@ with
                 else
                    tree.parent_statement_path_len
              end as parent_statement_path_len,
-             case
-                when ids.type in ('PROCEDURE', 'FUNCTION')
-                   and ids.usage = 'DEFINITION'
-                then
-                   case
-                      when tree.usage = 'DECLARATION'
-                         and ids.signature = tree.signature
-                      then
-                         'YES'
-                      else
-                         'NO'
-                   end
-             end as is_def_child_of_decl,
              ids.origin_con_id
         from tree
         join ids
@@ -850,43 +757,22 @@ with
          and tree.object_name = ids.object_name
          and tree.usage_id = ids.usage_context_id
    ) cycle owner, object_type, object_name, usage_id set is_cycle to 'Y' default 'N',
-   -- add the columns name_usage, is_new_proc to the list of identifiers
+   -- add the name_usage column to the list of identifiers
    tree_plus as (
       select tree.*,                                                 -- @formatter:off
              case
-                   when tree.usage = 'SQL_ID' then
-                      tree.type || ' statement (sql_id: ' || tree.name || ')'
-                   when tree.usage = 'SQL_STMT' then
-                      tree.type || ' statement'
-                   else
-                      tree.name || ' (' || lower(tree.type) || ' ' || lower(tree.usage) || ')'
-                end as name_usage,                                      -- @formatter:on
-             case
-                when type in ('PROCEDURE', 'FUNCTION')
-                   and usage = 'DEFINITION'
-                   and nvl(
-                      lag(
-                         procedure_signature,
-                         case is_def_child_of_decl
-                            when 'YES' then
-                               2
-                            else
-                               1
-                         end
-                      ) over (
-                         partition by tree.owner, tree.object_type, tree.object_name
-                         order by usage_id asc
-                      ),
-                      '----'
-                   ) != procedure_signature
-                then
-                   'YES'
-             end as is_new_proc
+                when tree.usage = 'SQL_ID' then
+                   tree.type || ' statement (sql_id: ' || tree.name || ')'
+                when tree.usage = 'SQL_STMT' then
+                   tree.type || ' statement'
+                else
+                   tree.name || ' (' || lower(tree.type) || ' ' || lower(tree.usage) || ')'
+             end as name_usage                                       -- @formatter:on
         from tree
    ),
    plscope_identifiers as (
-      -- add indent to column name_usage, fix column usage and adds the columns text, is_used,
-      -- proc_ends_before_line, proc_ends_before_col, ref_line, ref_col to the list of identifiers
+      -- add indent to column name_usage, fix column usage, and add the text, is_used,
+      -- ref_line, and ref_col columns to the list of identifiers
       select tree.owner,
              tree.object_type,
              tree.object_name,
@@ -957,46 +843,6 @@ with
              tree.usage_context_id,
              tree.is_fixed_context_id,
              tree.procedure_signature,
-             --tree.is_def_child_of_decl,    --uncomment if needed for debugging
-             --tree.is_new_proc,             --uncomment if needed for debugging
-             case
-                when tree.is_new_proc = 'YES' then
-                   coalesce(
-                      first_value(
-                         case
-                            when tree.is_new_proc = 'YES'
-                               or tree.usage_context_id = 1
-                            then
-                               tree.line
-                         end
-                      ) ignore nulls over (
-                         partition by tree.owner, tree.object_type, tree.object_name
-                         order by tree.usage_id
-                         rows between 1 following and unbounded following
-                      ),
-                      max(tree.line) over (
-                            partition by tree.owner, tree.object_type, tree.object_name
-                      ) + 1
-                   )
-             end as proc_ends_before_line,
-             case
-                when tree.is_new_proc = 'YES' then
-                   nvl(
-                      first_value(
-                         case
-                            when tree.is_new_proc = 'YES'
-                               or tree.usage_context_id = 1
-                            then
-                               tree.col
-                         end
-                      ) ignore nulls over (
-                         partition by tree.owner, tree.object_type, tree.object_name
-                         order by tree.usage_id
-                         rows between 1 following and unbounded following
-                      ),
-                      1
-                   )
-             end as proc_ends_before_col,
              refs.line as ref_line,         -- decl_line
              refs.col as ref_col,           -- decl_col
              tree.origin_con_id

--- a/sqldev/src/main/resources/com/salvis/plscope/sqldev/editor/plscope-utils-viewers.xml
+++ b/sqldev/src/main/resources/com/salvis/plscope/sqldev/editor/plscope-utils-viewers.xml
@@ -2367,7 +2367,31 @@ with
              tc.column_name,
              t.text,
              t.path_len
-        from plscope_tab_usage t
+        from ( select tu.owner,
+                      tu.object_type,
+                      tu.object_name,
+                      tu.line,
+                      tu.col,
+                      tu.procedure_name,
+                      tu.operation,
+                      tu.ref_owner,
+                      tu.ref_object_type,
+                      tu.ref_object_name,
+                      tu.text,
+                      tu.path_len
+                 from plscope_tab_usage tu
+                 left join sys.all_tables tab -- NOSONAR: avoid public synonyms
+                   on tu.ref_object_type = 'TABLE'
+                  and tab.owner = tu.owner
+                  and tab.table_name = tu.ref_object_name
+                where tu.is_base_object = 'YES'
+                  and tu.operation in ('INSERT', 'SELECT')
+                   -- PL/Scope records references to "columns" of object tables, not as
+                   -- column references, but as object attribute references instead.
+                   -- The scope_cols subquery cannot handle that, so we must exclude
+                   -- object tables here too.
+                  and not (tu.ref_object_type = 'TABLE' and tab.owner is null)
+             ) t
         left join scope_cols c
           on t.owner = c.owner
          and t.object_type = c.object_type
@@ -2379,9 +2403,7 @@ with
         join sys.all_tab_columns tc -- NOSONAR: avoid public synonym
           on tc.owner = t.owner
          and tc.table_name = t.ref_object_name
-       where t.is_base_object = 'YES'
-         and c.owner is null
-         and t.operation in ('INSERT', 'SELECT')
+       where c.owner is null
    ),
    base_cols as (
       select owner,

--- a/sqldev/src/main/resources/com/salvis/plscope/sqldev/editor/plscope-utils-viewers.xml
+++ b/sqldev/src/main/resources/com/salvis/plscope/sqldev/editor/plscope-utils-viewers.xml
@@ -1839,91 +1839,109 @@ with
          and src.name = tree.object_name
          and src.line = tree.line
    ),
-   dep as (
-      select owner as owner,
-             'TABLE' as type,
-             table_name as name,
-             null as referenced_owner,
-             null as referenced_type,
-             null as referenced_name
-        from sys.all_tables -- NOSONAR: avoid public synonym
-      union all
-      select owner,
-             type,
-             name,
-             referenced_owner,
-             referenced_type,
-             referenced_name
-        from sys.all_dependencies -- NOSONAR: avoid public synonym
-       where type in ('VIEW', 'MATERIALIZED VIEW', 'SYNONYM')
+   identifiers as ( 
+      select /*+ materialize */
+             ids.owner,
+             ids.object_type,
+             ids.object_name,
+             ids.procedure_name,
+             ids.usage,
+             ids.line,
+             ids.col,
+             ids.ref_owner,
+             ids.ref_object_type,
+             ids.ref_object_name,
+             ids.parent_statement_signature,
+             ids.text
+        from plscope_identifiers ids
+       where ids.type in ('VIEW', 'TABLE', 'SYNONYM')
    ),
-   -- recursive with clause to calculate ref_object_type_path
-   dep_graph_base (
+   -- direct and indirect dependencies; path_len = 0 for direct dependencies, 
+   -- otherwise the length of the chain of dependencies, i.e. level - 1; cycles
+   -- are possible here (with help from synonyms) so we need to detect them
+   dep_chains (
       owner,
-      object_type,
-      object_name,
+      type,
+      name,
       ref_owner,
-      ref_object_type,
-      ref_object_name,
-      ref_object_type_path,
+      ref_type,
+      ref_name,
       path_len
    ) as (
+      -- direct dependencies
+      select distinct
+             ids.ref_owner,
+             ids.ref_object_type,
+             ids.ref_object_name,
+             ids.ref_owner,
+             ids.ref_object_type,
+             ids.ref_object_name,
+             0
+        from identifiers ids
+       where ids.ref_object_type in ('VIEW', 'TABLE', 'SYNONYM')
+       union all
+      -- indirect dependencies
+      select /*+ no_merge(dep) */ 
+             par.owner,
+             par.type,
+             par.name,
+             dep.referenced_owner,
+             dep.referenced_type,
+             dep.referenced_name,
+             par.path_len + 1
+        from dep_chains par
+        join sys.all_dependencies dep  -- NOSONAR: avoid public synonym
+          on par.ref_owner = dep.owner
+         and par.ref_type = dep.type
+         and par.ref_name = dep.name
+       where par.ref_type <> 'VIEW'    -- don't resolve table usages in views
+         and dep.referenced_type in (  -- list of referenced types of interest
+            'VIEW', 
+            'TABLE', 
+            'SYNONYM',
+            'MATERIALIZED VIEW'        -- does MATERIALIZED VIEW belong here?
+         )
+   )
+   cycle ref_owner, ref_type, ref_name set is_cycle to 'Y' default 'N',
+   -- eliminate duplicate dependencies, keeping the minimum path_len; add the 
+   -- base_object_type column, which is the type of the first object (if any)
+   -- which is not a synonym, in case we're going down a chain of synonyms
+   dep_trans_closure as (
       select owner,
              type,
              name,
-             owner as ref_owner,
-             type as ref_object_type,
-             name as ref_object_name,
-             '/' || type as ref_object_type_path,
-             1 as path_len
-        from dep
-      union all
-      select dep.owner,
-             dep.type,
-             dep.name,
-             dep_graph_base.ref_owner,
-             dep_graph_base.ref_object_type,
-             dep_graph_base.ref_object_name,
-             case
-                when lengthb(dep_graph_base.ref_object_type_path) + lengthb('/') + lengthb(dep.type) <= 4000 then
-                   dep_graph_base.ref_object_type_path
-                   || '/'
-                   || dep.type
-                else
-                   -- prevent ref_object_type_path from overflowing: keep the first 3 elements, then
-                   -- remove enough elements to accomodate "..." + "/" + the tail end
-                   regexp_substr(dep_graph_base.ref_object_type_path, '^(/([^/]+/){3})')
-                   || '...'
-                   || regexp_replace(
-                      substr(dep_graph_base.ref_object_type_path, instr(dep_graph_base.ref_object_type_path, '/', 1, 4) + 1
-                         + lengthb('.../') + lengthb(dep.type)),
-                      '^[^/]*')
-                   || '/'
-                   || dep.type
-             end as ref_object_type_path,
-             dep_graph_base.path_len + 1 as path_len
-        from dep_graph_base
-        join dep
-          on dep_graph_base.owner = dep.referenced_owner
-         and dep_graph_base.object_type = dep.referenced_type
-         and dep_graph_base.object_name = dep.referenced_name
-   ) cycle owner, object_type, object_name set is_cycle to 'Y' default 'N',
-   -- remove duplicate rows
-   dep_graph as (
-      select distinct
-             owner,
-             object_type,
-             object_name,
              ref_owner,
-             ref_object_type,
-             ref_object_name,
-             ref_object_type_path,
-             path_len
-        from dep_graph_base
+             ref_type,
+             ref_name,
+             min(path_len)  as path_len,
+             nullif(                            -- @formatter:off
+                min(ref_type)
+                keep (
+                   dense_rank first
+                   order by 
+                      case
+                         when ref_type = 'SYNONYM' then
+                            null
+                         else
+                            min(path_len)
+                      end asc nulls last,
+                      min(path_len)
+                )
+                over (
+                   partition by owner, type, name
+                ),
+                'SYNONYM'
+             )  as base_obj_type                -- @formatter:on
+        from dep_chains
+       group by owner,
+             type,
+             name,
+             ref_owner,
+             ref_type,
+             ref_name      
    ),
-   tab_usage as (
-      select /*+use_hash(ids) use_hash(dep_graph) use_hash(refs)*/
-             ids.owner,
+   plscope_tab_usage as (
+      select ids.owner,
              ids.object_type,
              ids.object_name,
              ids.line,
@@ -1935,50 +1953,28 @@ with
                 else
                    ids.usage
              end as operation,
-             dep_graph.ref_owner,
-             dep_graph.ref_object_type,
-             dep_graph.ref_object_name,
+             dep.ref_owner,
+             dep.ref_type  as ref_object_type,
+             dep.ref_name  as ref_object_name,
              case
-                when dep_graph.path_len = 1 then
+                when dep.path_len = 0 then
                    'YES'
                 else
                    'NO'
              end as direct_dependency,
-             dep_graph.ref_object_type_path,
-             lead(dep_graph.ref_object_type_path) over (
-                order by ids.owner, ids.object_type, ids.object_name, ids.line, ids.col, dep_graph.path_len
-             ) as next_ref_object_type_path,
              ids.text,
-             dep_graph.path_len
-        from plscope_identifiers ids
-        join dep_graph
-          on dep_graph.owner = ids.ref_owner
-         and dep_graph.object_type = ids.ref_object_type
-         and dep_graph.object_name = ids.ref_object_name
-        left join sys.all_statements refs -- NOSONAR: avoid public synonym
-          on refs.signature = parent_statement_signature
-       where ids.type in ('VIEW', 'TABLE', 'SYNONYM')
-   ),
-   plscope_tab_usage as (
-      select owner,
-             object_type,
-             object_name,
-             line,
-             col,
-             procedure_name,
-             operation,
-             ref_owner,
-             ref_object_type,
-             ref_object_name,
-             direct_dependency,
-             text,
-             path_len,
-             ref_object_type_path,
-             next_ref_object_type_path
-        from tab_usage
-       where (ref_object_type != 'SYNONYM' or next_ref_object_type_path in ('/VIEW/SYNONYM', '/TABLE/SYNONYM'))
+             dep.path_len
+        from identifiers ids
+        join dep_trans_closure dep
+          on dep.owner = ids.ref_owner
+         and dep.type = ids.ref_object_type
+         and dep.name = ids.ref_object_name
+         and dep.base_obj_type is not null  -- drop syn. refs not leading to tables/views
+        left join sys.all_statements refs   -- NOSONAR: avoid public synonym
+          on refs.signature = ids.parent_statement_signature
    )
-select case
+select
+       case
           when object_type in ('FUNCTION', 'PACKAGE', 'PACKAGE BODY', 'PROCEDURE', 'TRIGGER', 'TYPE', 'TYPE BODY') then
              'SQLDEV:LINK:'
              || owner
@@ -2006,9 +2002,8 @@ select case
        col as "Col",
        text as "Text"
   from plscope_tab_usage
- where (ref_object_type != 'SYNONYM' or next_ref_object_type_path in ('/VIEW/SYNONYM', '/TABLE/SYNONYM'))
-   -- resolve synonyms as indirect dependencies only (do not resolve table usages in views)
-   and (path_len = 1 or path_len = 2 and ref_object_type_path like '%SYNONYM')
+ where -- skip intermediate synonyms
+       not (ref_object_type = 'SYNONYM' and path_len >= 1)
  order by length(object_type), line, col, path_len
 ]]>
             </sql>
@@ -2524,91 +2519,135 @@ with
          and src.name = tree.object_name
          and src.line = tree.line
    ),
-   dep as (
-      select owner as owner,
-             'TABLE' as type,
-             table_name as name,
-             null as referenced_owner,
-             null as referenced_type,
-             null as referenced_name
-        from sys.all_tables -- NOSONAR: avoid public synonym
-      union all
-      select owner,
-             type,
-             name,
-             referenced_owner,
-             referenced_type,
-             referenced_name
-        from sys.all_dependencies -- NOSONAR: avoid public synonym
-       where type in ('VIEW', 'MATERIALIZED VIEW', 'SYNONYM')
+   identifiers as ( 
+      select /*+ materialize */
+             ids.owner,
+             ids.object_type,
+             ids.object_name,
+             ids.procedure_name,
+             ids.type,
+             ids.name,
+             ids.usage,
+             ids.line,
+             ids.col,
+             ids.ref_owner,
+             ids.ref_object_type,
+             ids.ref_object_name,
+             ids.parent_statement_signature,
+             ids.text,
+             ids.path_len
+        from plscope_identifiers ids
+       where ids.type in ('VIEW', 'TABLE', 'SYNONYM')
+             or (ids.type = 'COLUMN' and ids.usage != 'DECLARATION')
    ),
-   -- recursive with clause to calculate ref_object_type_path
-   dep_graph_base (
+   -- direct and indirect dependencies; path_len = 0 for direct dependencies, 
+   -- otherwise the length of the dependency chain, i.e. level - 1; cycles are
+   -- possible here (with help from synonyms) so we need to detect them
+   dep_chains (
       owner,
-      object_type,
-      object_name,
+      type,
+      name,
       ref_owner,
-      ref_object_type,
-      ref_object_name,
-      ref_object_type_path,
+      ref_type,
+      ref_name,
       path_len
    ) as (
+      -- direct dependencies
+      select distinct
+             ids.ref_owner,
+             ids.ref_object_type,
+             ids.ref_object_name,
+             ids.ref_owner,
+             ids.ref_object_type,
+             ids.ref_object_name,
+             0
+        from identifiers ids
+       where ids.ref_object_type in ('VIEW', 'TABLE', 'SYNONYM')
+       union all
+      -- indirect dependencies
+      select /*+ no_merge(dep) */ 
+             par.owner,
+             par.type,
+             par.name,
+             dep.referenced_owner,
+             dep.referenced_type,
+             dep.referenced_name,
+             par.path_len + 1
+        from dep_chains par
+        join sys.all_dependencies dep  -- NOSONAR: avoid public synonym
+          on par.ref_owner = dep.owner
+         and par.ref_type = dep.type
+         and par.ref_name = dep.name
+       where par.ref_type <> 'VIEW'    -- don't resolve table usages in views
+         and dep.referenced_type in (  -- list of referenced types of interest
+                'VIEW', 
+                'TABLE', 
+                'SYNONYM',
+                'MATERIALIZED VIEW'    -- does MATERIALIZED VIEW belong here?
+             )
+   )
+   cycle ref_owner, ref_type, ref_name set is_cycle to 'Y' default 'N',
+   -- eliminate duplicate dependencies, keeping the minimum path_len; add the 
+   -- base_object_type column, which is the type of the first object (if any)
+   -- which is not a synonym, in case we're going down a chain of synonyms;
+   -- the is_base_object flag is set to 'YES' for that object, otherwise null
+   dep_trans_closure as (
       select owner,
              type,
              name,
-             owner as ref_owner,
-             type as ref_object_type,
-             name as ref_object_name,
-             '/' || type as ref_object_type_path,
-             1 as path_len
-        from dep
-      union all
-      select dep.owner,
-             dep.type,
-             dep.name,
-             dep_graph_base.ref_owner,
-             dep_graph_base.ref_object_type,
-             dep_graph_base.ref_object_name,
-             case
-                when lengthb(dep_graph_base.ref_object_type_path) + lengthb('/') + lengthb(dep.type) <= 4000 then
-                   dep_graph_base.ref_object_type_path
-                   || '/'
-                   || dep.type
-                else
-                   -- prevent ref_object_type_path from overflowing: keep the first 3 elements, then
-                   -- remove enough elements to accomodate "..." + "/" + the tail end
-                   regexp_substr(dep_graph_base.ref_object_type_path, '^(/([^/]+/){3})')
-                   || '...'
-                   || regexp_replace(
-                      substr(dep_graph_base.ref_object_type_path, instr(dep_graph_base.ref_object_type_path, '/', 1, 4) + 1
-                         + lengthb('.../') + lengthb(dep.type)),
-                      '^[^/]*')
-                   || '/'
-                   || dep.type
-             end as ref_object_type_path,
-             dep_graph_base.path_len + 1 as path_len
-        from dep_graph_base
-        join dep
-          on dep_graph_base.owner = dep.referenced_owner
-         and dep_graph_base.object_type = dep.referenced_type
-         and dep_graph_base.object_name = dep.referenced_name
-   ) cycle owner, object_type, object_name set is_cycle to 'Y' default 'N',
-   -- remove duplicate rows
-   dep_graph as (
-      select distinct
-             owner,
-             object_type,
-             object_name,
              ref_owner,
-             ref_object_type,
-             ref_object_name,
-             ref_object_type_path,
-             path_len
-        from dep_graph_base
+             ref_type,
+             ref_name,
+             min(path_len)  as path_len,
+             nullif(                            -- @formatter:off
+                min(ref_type)
+                keep (
+                   dense_rank first
+                   order by 
+                      case
+                         when ref_type = 'SYNONYM' then
+                            null
+                         else
+                            min(path_len)
+                      end asc nulls last,
+                      min(path_len)
+                )
+                over (
+                   partition by owner, type, name
+                ),
+                'SYNONYM'
+             )  as base_obj_type,               -- @formatter:on
+             case                               -- @formatter:off
+                -- remark: disregarding the case when there are only SYNONYMs in the 
+                -- dependency chain: such chains are filtered out in tab_usage subquery
+                when min(path_len) = min(min(path_len))
+                      keep (
+                         dense_rank first
+                         order by 
+                            case
+                               when ref_type = 'SYNONYM' then
+                                  null
+                               else
+                                  min(path_len)
+                            end asc nulls last,
+                            min(path_len)
+                      )
+                      over (
+                         partition by owner, type, name
+                      ) 
+                then
+                   cast('YES' as varchar2(3 char))
+             end  as is_base_object             -- @formatter:on
+        from dep_chains
+       group by owner,
+             type,
+             name,
+             ref_owner,
+             ref_type,
+             ref_name      
    ),
-   tab_usage as (
-      select /*+use_hash(ids) use_hash(dep_graph) use_hash(refs)*/
-             ids.owner,
+   plscope_tab_usage as (
+      select ids.owner,
              ids.object_type,
              ids.object_name,
              ids.line,
@@ -2620,50 +2659,30 @@ with
                 else
                    ids.usage
              end as operation,
-             dep_graph.ref_owner,
-             dep_graph.ref_object_type,
-             dep_graph.ref_object_name,
+             dep.ref_owner,
+             dep.ref_type  as ref_object_type,
+             dep.ref_name  as ref_object_name,
              case
-                when dep_graph.path_len = 1 then
+                when dep.path_len = 0 then
                    'YES'
                 else
                    'NO'
              end as direct_dependency,
-             dep_graph.ref_object_type_path,
-             lead(dep_graph.ref_object_type_path) over (
-                order by ids.owner, ids.object_type, ids.object_name, ids.line, ids.col, dep_graph.path_len
-             ) as next_ref_object_type_path,
              ids.text,
+             dep.is_base_object,
              ids.path_len
-        from plscope_identifiers ids
-        join dep_graph
-          on dep_graph.owner = ids.ref_owner
-         and dep_graph.object_type = ids.ref_object_type
-         and dep_graph.object_name = ids.ref_object_name
-        left join sys.all_statements refs -- NOSONAR: avoid public synonym
-          on refs.signature = parent_statement_signature
+        from identifiers ids
+        join dep_trans_closure dep
+          on dep.owner = ids.ref_owner
+         and dep.type = ids.ref_object_type
+         and dep.name = ids.ref_object_name
+        left join sys.all_statements refs   -- NOSONAR: avoid public synonym
+          on refs.signature = ids.parent_statement_signature   
        where ids.type in ('VIEW', 'TABLE', 'SYNONYM')
-   ),
-   plscope_tab_usage as (
-      select owner,
-             object_type,
-             object_name,
-             line,
-             col,
-             procedure_name,
-             operation,
-             ref_owner,
-             ref_object_type,
-             ref_object_name,
-             direct_dependency,
-             text,
-             path_len
-        from tab_usage
-       where (ref_object_type != 'SYNONYM' or next_ref_object_type_path in ('/VIEW/SYNONYM', '/TABLE/SYNONYM'))
+         and dep.base_obj_type is not null  -- drop syn. refs not leading to tables/views
    ),
    scope_cols as (
-      select /*+use_hash(ids) use_hash(refs) */
-             ids.owner,
+      select ids.owner,
              ids.object_type,
              ids.object_name,
              ids.line,
@@ -2681,46 +2700,39 @@ with
              ids.name as column_name,
              ids.text,
              ids.path_len
-        from plscope_identifiers ids
+        from identifiers ids
         left join sys.all_statements refs -- NOSONAR: avoid public synonym
           on refs.signature = parent_statement_signature
        where ids.type = 'COLUMN'
          and ids.usage != 'DECLARATION'
    ),
    missing_cols as (
-      select /*+use_hash(t) use_hash(s) use_hash(o) use_hash(c) use_hash(tc) */
-             t.owner,
+      select t.owner,
              t.object_type,
              t.object_name,
              t.line,
              t.col,
              t.procedure_name,
              t.operation,
-             coalesce(o.owner, t.ref_owner) as ref_owner,
-             coalesce(o.object_type, t.ref_object_type) as ref_object_type,
-             coalesce(o.object_name, t.ref_object_name) as ref_object_name,
+             t.ref_owner,
+             t.ref_object_type,
+             t.ref_object_name,
              tc.column_name,
              t.text,
              t.path_len
         from plscope_tab_usage t
-        left join sys.all_synonyms s -- NOSONAR: avoid public synonym
-          on s.owner = t.ref_owner
-         and s.synonym_name = t.ref_object_name
-        left join sys.all_objects o -- NOSONAR: avoid public synonym
-          on o.owner = s.table_owner
-         and o.object_name = s.table_name
         left join scope_cols c
           on t.owner = c.owner
          and t.object_type = c.object_type
          and t.object_name = c.object_name
          and t.procedure_name = c.procedure_name
-         and coalesce(o.owner, t.ref_owner) = c.ref_owner
-         and coalesce(o.object_type, t.ref_object_type) = c.ref_object_type
-         and coalesce(o.object_name, t.ref_object_name) = c.ref_object_name
+         and t.ref_owner = c.ref_owner
+         and t.ref_object_type = c.ref_object_type
+         and t.ref_object_name = c.ref_object_name
         join sys.all_tab_columns tc -- NOSONAR: avoid public synonym
           on tc.owner = t.owner
-         and tc.table_name = coalesce(o.object_name, t.ref_object_name)
-       where t.direct_dependency = 'YES'
+         and tc.table_name = t.ref_object_name
+       where t.is_base_object = 'YES'
          and c.owner is null
          and t.operation in ('INSERT', 'SELECT')
    ),

--- a/sqldev/src/main/resources/com/salvis/plscope/sqldev/editor/plscope-utils-viewers.xml
+++ b/sqldev/src/main/resources/com/salvis/plscope/sqldev/editor/plscope-utils-viewers.xml
@@ -1716,6 +1716,8 @@ with
           on dep.owner = ids.ref_owner
          and dep.type = ids.ref_object_type
          and dep.name = ids.ref_object_name
+         and (dep.ref_type <> 'SYNONYM'     -- ignore synonyms unless directly referenced
+                or dep.path_len = 0)
          and dep.base_obj_type is not null  -- drop syn. refs not leading to tables/views
         left join sys.all_statements refs   -- NOSONAR: avoid public synonym
           on refs.signature = ids.parent_statement_signature
@@ -2322,6 +2324,8 @@ with
         left join sys.all_statements refs   -- NOSONAR: avoid public synonym
           on refs.signature = ids.parent_statement_signature   
        where ids.type in ('VIEW', 'TABLE', 'SYNONYM')
+         and (dep.ref_type <> 'SYNONYM'     -- ignore synonyms unless directly referenced
+                or dep.path_len = 0)
          and dep.base_obj_type is not null  -- drop syn. refs not leading to tables/views
    ),
    scope_cols as (

--- a/sqldev/src/main/resources/com/salvis/plscope/sqldev/editor/plscope-utils-viewers.xml
+++ b/sqldev/src/main/resources/com/salvis/plscope/sqldev/editor/plscope-utils-viewers.xml
@@ -1109,20 +1109,6 @@ select case
 			<query minversion="11.1">
 				<sql><![CDATA[
 with
-   src as (
-      select /*+ materialize */
-             owner,
-             type,
-             name,
-             line,
-             text
-        from sys.all_source
-       where owner = :OBJECT_OWNER
-         and type in (
-                upper(replace(:OBJECT_TYPE, 'plscope-utils-')), upper(replace(:OBJECT_TYPE, 'plscope-utils-')) || ' BODY'
-             )
-         and name = :OBJECT_NAME
-   ),
    refs as (
       select /*+materialize */
              signature
@@ -1162,7 +1148,7 @@ select case
   from refs
   join sys.all_identifiers ids
     on ids.signature = refs.signature
-  left join src
+  left join sys.all_source src
     on src.owner = ids.owner
    and src.type = ids.object_type
    and src.name = ids.object_name

--- a/sqldev/src/main/resources/com/salvis/plscope/sqldev/editor/plscope-utils-viewers.xml
+++ b/sqldev/src/main/resources/com/salvis/plscope/sqldev/editor/plscope-utils-viewers.xml
@@ -1381,7 +1381,7 @@ with
              )
          and object_name = :OBJECT_NAME
    ),
-   -- SQL identifiers filtered by user
+   -- SQL identifiers filtered by SQLDev bind variables
    sql_ids as (
       select /*+ materialize */
              owner,
@@ -1397,7 +1397,11 @@ with
              usage_context_id,
              origin_con_id
         from sys.all_statements -- NOSONAR: avoid public synonym
-       where owner like nvl(:OBJECT_OWNER, user)
+       where owner = :OBJECT_OWNER
+         and object_type in (
+                upper(replace(:OBJECT_TYPE, 'plscope-utils-')), upper(replace(:OBJECT_TYPE, 'plscope-utils-')) || ' BODY'
+             )
+         and object_name = :OBJECT_NAME
    ),
    -- full list of identifiers (PL/SQL and SQL) with columns is_sql_stmt and procedure_scope
    fids as (
@@ -1953,7 +1957,7 @@ with
              )
          and object_name = :OBJECT_NAME
    ),
-   -- SQL identifiers filtered by user
+   -- SQL identifiers filtered by SQLDev bind variables
    sql_ids as (
       select /*+ materialize */
              owner,

--- a/sqldev/src/main/resources/com/salvis/plscope/sqldev/editor/plscope-utils-viewers.xml
+++ b/sqldev/src/main/resources/com/salvis/plscope/sqldev/editor/plscope-utils-viewers.xml
@@ -1506,8 +1506,7 @@ with
    ),
    -- recursive with clause to extend the list of identifiers with the columns
    -- procedure_name, procedure_scope, name_path, path_len (level), procedure_signature,
-   -- parent_statement_type, parent_statement_signature, parent_statement_path_len,
-   -- is_def_child_of_decl
+   -- parent_statement_type, parent_statement_signature, parent_statement_path_len
    tree (
       owner,
       object_type,
@@ -1530,7 +1529,6 @@ with
       parent_statement_type,
       parent_statement_signature,
       parent_statement_path_len,
-      is_def_child_of_decl,
       origin_con_id
    ) as (
       select owner,
@@ -1563,7 +1561,6 @@ with
              cast(null as varchar2(18 char)) as parent_statement_type,
              cast(null as varchar2(32 char)) as parent_statement_signature,
              cast(null as number) as parent_statement_path_len,
-             cast(null as varchar2(3 char)) as is_def_child_of_decl,
              origin_con_id
         from ids
        where usage_context_id = 0  -- top-level identifiers
@@ -1658,19 +1655,6 @@ with
                 else
                    tree.parent_statement_path_len
              end as parent_statement_path_len,
-             case
-                when ids.type in ('PROCEDURE', 'FUNCTION')
-                   and ids.usage = 'DEFINITION'
-                then
-                   case
-                      when tree.usage = 'DECLARATION'
-                         and ids.signature = tree.signature
-                      then
-                         'YES'
-                      else
-                         'NO'
-                   end
-             end as is_def_child_of_decl,
              ids.origin_con_id
         from tree
         join ids
@@ -1679,7 +1663,7 @@ with
          and tree.object_name = ids.object_name
          and tree.usage_id = ids.usage_context_id
    ) cycle owner, object_type, object_name, usage_id set is_cycle to 'Y' default 'N',
-   -- add the columns name_usage, is_new_proc to the list of identifiers
+   -- add the name_usage column to the list of identifiers
    tree_plus as (
       select tree.*,                                                 -- @formatter:off
              case
@@ -1689,33 +1673,12 @@ with
                       tree.type || ' statement'
                    else
                       tree.name || ' (' || lower(tree.type) || ' ' || lower(tree.usage) || ')'
-                end as name_usage,                                      -- @formatter:on
-             case
-                when type in ('PROCEDURE', 'FUNCTION')
-                   and usage = 'DEFINITION'
-                   and nvl(
-                      lag(
-                         procedure_signature,
-                         case is_def_child_of_decl
-                            when 'YES' then
-                               2
-                            else
-                               1
-                         end
-                      ) over (
-                         partition by tree.owner, tree.object_type, tree.object_name
-                         order by usage_id asc
-                      ),
-                      '----'
-                   ) != procedure_signature
-                then
-                   'YES'
-             end as is_new_proc
+                end as name_usage                                    -- @formatter:on
         from tree
    ),
    plscope_identifiers as (
-      -- add indent to column name_usage, fix column usage and adds the columns text, is_used,
-      -- proc_ends_before_line, proc_ends_before_col, ref_line, ref_col to the list of identifiers
+      -- add indent to column name_usage, fix column usage, and add the text, ref_line,
+      -- and ref_col columns to the list of identifiers
       select tree.owner,
              tree.object_type,
              tree.object_name,
@@ -1742,7 +1705,7 @@ with
              tree.path_len,
              tree.type,
              case
-                   -- make SQL_ID and SQL_STMT pseudo-usages appear as EXECUTE
+                -- make SQL_ID and SQL_STMT pseudo-usages appear as EXECUTE
                 when tree.usage in ('SQL_ID', 'SQL_STMT') then
                    'EXECUTE'
                 else
@@ -1755,77 +1718,11 @@ with
              tree.parent_statement_type,
              tree.parent_statement_signature,
              tree.parent_statement_path_len,
-             case
-                   -- wrong result, if used in statements which do not register usage,
-                   -- such as a variable for dynamic_sql_stmt in EXECUTE IMMEDIATE.
-                   -- Bug 26351814.
-                when tree.object_type in ('PACKAGE BODY', 'PROCEDURE', 'FUNCTION', 'TYPE BODY')
-                   and tree.usage = 'DECLARATION'
-                   and tree.type not in ('LABEL')
-                then
-                   case
-                      when count(
-                            case
-                               when tree.usage not in ('DECLARATION', 'ASSIGNMENT')
-                                  or (tree.type in ('FORMAL OUT', 'FORMAL IN OUT')
-                                     and tree.usage = 'ASSIGNMENT')
-                               then
-                                  1
-                            end
-                         ) over (
-                            partition by tree.owner, tree.object_name, tree.object_type, tree.signature
-                         ) = 0
-                      then
-                         'NO'
-                      else
-                         'YES'
-                   end
-             end as is_used,
              tree.signature,
              tree.usage_id,
              tree.usage_context_id,
              tree.is_fixed_context_id,
              tree.procedure_signature,
-             --tree.is_def_child_of_decl,    --uncomment if needed for debugging
-             --tree.is_new_proc,             --uncomment if needed for debugging
-             case
-                when tree.is_new_proc = 'YES' then
-                   coalesce(
-                      first_value(
-                         case
-                            when tree.is_new_proc = 'YES'
-                               or tree.usage_context_id = 1
-                            then
-                               tree.line
-                         end
-                      ) ignore nulls over (
-                         partition by tree.owner, tree.object_type, tree.object_name
-                         order by tree.usage_id
-                         rows between 1 following and unbounded following
-                      ),
-                      max(tree.line) over (
-                            partition by tree.owner, tree.object_type, tree.object_name
-                      ) + 1
-                   )
-             end as proc_ends_before_line,
-             case
-                when tree.is_new_proc = 'YES' then
-                   nvl(
-                      first_value(
-                         case
-                            when tree.is_new_proc = 'YES'
-                               or tree.usage_context_id = 1
-                            then
-                               tree.col
-                         end
-                      ) ignore nulls over (
-                         partition by tree.owner, tree.object_type, tree.object_name
-                         order by tree.usage_id
-                         rows between 1 following and unbounded following
-                      ),
-                      1
-                   )
-             end as proc_ends_before_col,
              refs.line as ref_line,         -- decl_line
              refs.col as ref_col,           -- decl_col
              tree.origin_con_id
@@ -1973,8 +1870,7 @@ with
         left join sys.all_statements refs   -- NOSONAR: avoid public synonym
           on refs.signature = ids.parent_statement_signature
    )
-select
-       case
+select case
           when object_type in ('FUNCTION', 'PACKAGE', 'PACKAGE BODY', 'PROCEDURE', 'TRIGGER', 'TYPE', 'TYPE BODY') then
              'SQLDEV:LINK:'
              || owner
@@ -2186,8 +2082,7 @@ with
    ),
    -- recursive with clause to extend the list of identifiers with the columns
    -- procedure_name, procedure_scope, name_path, path_len (level), procedure_signature,
-   -- parent_statement_type, parent_statement_signature, parent_statement_path_len,
-   -- is_def_child_of_decl
+   -- parent_statement_type, parent_statement_signature, parent_statement_path_len
    tree (
       owner,
       object_type,
@@ -2210,7 +2105,6 @@ with
       parent_statement_type,
       parent_statement_signature,
       parent_statement_path_len,
-      is_def_child_of_decl,
       origin_con_id
    ) as (
       select owner,
@@ -2243,7 +2137,6 @@ with
              cast(null as varchar2(18 char)) as parent_statement_type,
              cast(null as varchar2(32 char)) as parent_statement_signature,
              cast(null as number) as parent_statement_path_len,
-             cast(null as varchar2(3 char)) as is_def_child_of_decl,
              origin_con_id
         from ids
        where usage_context_id = 0  -- top-level identifiers
@@ -2338,19 +2231,6 @@ with
                 else
                    tree.parent_statement_path_len
              end as parent_statement_path_len,
-             case
-                when ids.type in ('PROCEDURE', 'FUNCTION')
-                   and ids.usage = 'DEFINITION'
-                then
-                   case
-                      when tree.usage = 'DECLARATION'
-                         and ids.signature = tree.signature
-                      then
-                         'YES'
-                      else
-                         'NO'
-                   end
-             end as is_def_child_of_decl,
              ids.origin_con_id
         from tree
         join ids
@@ -2359,7 +2239,7 @@ with
          and tree.object_name = ids.object_name
          and tree.usage_id = ids.usage_context_id
    ) cycle owner, object_type, object_name, usage_id set is_cycle to 'Y' default 'N',
-   -- add the columns name_usage, is_new_proc to the list of identifiers
+   -- add the name_usage column to the list of identifiers
    tree_plus as (
       select tree.*,                                                 -- @formatter:off
              case
@@ -2369,33 +2249,12 @@ with
                       tree.type || ' statement'
                    else
                       tree.name || ' (' || lower(tree.type) || ' ' || lower(tree.usage) || ')'
-                end as name_usage,                                      -- @formatter:on
-             case
-                when type in ('PROCEDURE', 'FUNCTION')
-                   and usage = 'DEFINITION'
-                   and nvl(
-                      lag(
-                         procedure_signature,
-                         case is_def_child_of_decl
-                            when 'YES' then
-                               2
-                            else
-                               1
-                         end
-                      ) over (
-                         partition by tree.owner, tree.object_type, tree.object_name
-                         order by usage_id asc
-                      ),
-                      '----'
-                   ) != procedure_signature
-                then
-                   'YES'
-             end as is_new_proc
+                end as name_usage                                    -- @formatter:on
         from tree
    ),
    plscope_identifiers as (
-      -- add indent to column name_usage, fix column usage and adds the columns text, is_used,
-      -- proc_ends_before_line, proc_ends_before_col, ref_line, ref_col to the list of identifiers
+      -- add indent to column name_usage, fix column usage, and add the text, ref_line,
+      -- and ref_col columns to the list of identifiers
       select tree.owner,
              tree.object_type,
              tree.object_name,
@@ -2422,7 +2281,7 @@ with
              tree.path_len,
              tree.type,
              case
-                   -- make SQL_ID and SQL_STMT pseudo-usages appear as EXECUTE
+                -- make SQL_ID and SQL_STMT pseudo-usages appear as EXECUTE
                 when tree.usage in ('SQL_ID', 'SQL_STMT') then
                    'EXECUTE'
                 else
@@ -2435,77 +2294,11 @@ with
              tree.parent_statement_type,
              tree.parent_statement_signature,
              tree.parent_statement_path_len,
-             case
-                   -- wrong result, if used in statements which do not register usage,
-                   -- such as a variable for dynamic_sql_stmt in EXECUTE IMMEDIATE.
-                   -- Bug 26351814.
-                when tree.object_type in ('PACKAGE BODY', 'PROCEDURE', 'FUNCTION', 'TYPE BODY')
-                   and tree.usage = 'DECLARATION'
-                   and tree.type not in ('LABEL')
-                then
-                   case
-                      when count(
-                            case
-                               when tree.usage not in ('DECLARATION', 'ASSIGNMENT')
-                                  or (tree.type in ('FORMAL OUT', 'FORMAL IN OUT')
-                                     and tree.usage = 'ASSIGNMENT')
-                               then
-                                  1
-                            end
-                         ) over (
-                            partition by tree.owner, tree.object_name, tree.object_type, tree.signature
-                         ) = 0
-                      then
-                         'NO'
-                      else
-                         'YES'
-                   end
-             end as is_used,
              tree.signature,
              tree.usage_id,
              tree.usage_context_id,
              tree.is_fixed_context_id,
              tree.procedure_signature,
-             --tree.is_def_child_of_decl,    --uncomment if needed for debugging
-             --tree.is_new_proc,             --uncomment if needed for debugging
-             case
-                when tree.is_new_proc = 'YES' then
-                   coalesce(
-                      first_value(
-                         case
-                            when tree.is_new_proc = 'YES'
-                               or tree.usage_context_id = 1
-                            then
-                               tree.line
-                         end
-                      ) ignore nulls over (
-                         partition by tree.owner, tree.object_type, tree.object_name
-                         order by tree.usage_id
-                         rows between 1 following and unbounded following
-                      ),
-                      max(tree.line) over (
-                            partition by tree.owner, tree.object_type, tree.object_name
-                      ) + 1
-                   )
-             end as proc_ends_before_line,
-             case
-                when tree.is_new_proc = 'YES' then
-                   nvl(
-                      first_value(
-                         case
-                            when tree.is_new_proc = 'YES'
-                               or tree.usage_context_id = 1
-                            then
-                               tree.col
-                         end
-                      ) ignore nulls over (
-                         partition by tree.owner, tree.object_type, tree.object_name
-                         order by tree.usage_id
-                         rows between 1 following and unbounded following
-                      ),
-                      1
-                   )
-             end as proc_ends_before_col,
              refs.line as ref_line,         -- decl_line
              refs.col as ref_col,           -- decl_col
              tree.origin_con_id

--- a/sqldev/src/main/resources/com/salvis/plscope/sqldev/editor/plscope-utils-viewers.xml
+++ b/sqldev/src/main/resources/com/salvis/plscope/sqldev/editor/plscope-utils-viewers.xml
@@ -1740,7 +1740,7 @@ with
          and src.name = tree.object_name
          and src.line = tree.line
    ),
-   identifiers as ( 
+   table_usage_ids as ( 
       select /*+ materialize */
              ids.owner,
              ids.object_type,
@@ -1778,7 +1778,7 @@ with
              ids.ref_object_type,
              ids.ref_object_name,
              0
-        from identifiers ids
+        from table_usage_ids ids
        where ids.ref_object_type in ('VIEW', 'TABLE', 'SYNONYM')
        union all
       -- indirect dependencies
@@ -1865,7 +1865,7 @@ with
              end as direct_dependency,
              ids.text,
              dep.path_len
-        from identifiers ids
+        from table_usage_ids ids
         join dep_trans_closure dep
           on dep.owner = ids.ref_owner
          and dep.type = ids.ref_object_type
@@ -2316,7 +2316,7 @@ with
          and src.name = tree.object_name
          and src.line = tree.line
    ),
-   identifiers as ( 
+   tableorcolumn_usage_ids as ( 
       select /*+ materialize */
              ids.owner,
              ids.object_type,
@@ -2358,7 +2358,7 @@ with
              ids.ref_object_type,
              ids.ref_object_name,
              0
-        from identifiers ids
+        from tableorcolumn_usage_ids ids
        where ids.ref_object_type in ('VIEW', 'TABLE', 'SYNONYM')
        union all
       -- indirect dependencies
@@ -2468,7 +2468,7 @@ with
              ids.text,
              dep.is_base_object,
              ids.path_len
-        from identifiers ids
+        from tableorcolumn_usage_ids ids
         join dep_trans_closure dep
           on dep.owner = ids.ref_owner
          and dep.type = ids.ref_object_type
@@ -2497,7 +2497,7 @@ with
              ids.name as column_name,
              ids.text,
              ids.path_len
-        from identifiers ids
+        from tableorcolumn_usage_ids ids
         left join sys.all_statements refs -- NOSONAR: avoid public synonym
           on refs.signature = parent_statement_signature
        where ids.type = 'COLUMN'

--- a/sqldev/src/main/resources/com/salvis/plscope/sqldev/report/plscope-utils-reports.xml
+++ b/sqldev/src/main/resources/com/salvis/plscope/sqldev/report/plscope-utils-reports.xml
@@ -696,7 +696,7 @@ with
         from sys.all_source -- NOSONAR: avoid public synonym
        where owner like nvl(:OBJECT_OWNER, user)
    ),
-   -- PL/SQL identifiers filtered by PLSCOPE context attributes
+   -- PL/SQL identifiers filtered by user
    pls_ids as (
       select /*+ materialize */
              owner,

--- a/sqldev/src/main/resources/com/salvis/plscope/sqldev/report/plscope-utils-reports.xml
+++ b/sqldev/src/main/resources/com/salvis/plscope/sqldev/report/plscope-utils-reports.xml
@@ -108,7 +108,7 @@ select case
 	</display>
 	<display id="27802dea-015d-1000-8001-c0a80106a1a4" type="" style="Table" enable="true">
 		<name><![CDATA[UDF Calls in SQL Statements]]></name>
-		<description><![CDATA[Reports static SELECT, INSERT, UPDATE, DELETE and MERGE statements within packages, procedures, functions, triggers and types using user-defined function calls.]]></description>
+		<description><![CDATA[Reports calls to user-defined functions in static SQL statements.]]></description>
 		<tooltip><![CDATA[Reports user-defined function calls in SQL statements]]></tooltip>
 		<drillclass><![CDATA[]]></drillclass>
 		<CustomValues>
@@ -271,8 +271,7 @@ select case
       ),
       -- recursive with clause to extend the list of identifiers with the columns
       -- procedure_name, procedure_scope, name_path, path_len (level), procedure_signature,
-      -- parent_statement_type, parent_statement_signature, parent_statement_path_len,
-      -- is_def_child_of_decl
+      -- parent_statement_type, parent_statement_signature, parent_statement_path_len
       tree (
          owner,
          object_type,
@@ -295,7 +294,6 @@ select case
          parent_statement_type,
          parent_statement_signature,
          parent_statement_path_len,
-         is_def_child_of_decl,
          origin_con_id
       ) as (
          select owner,
@@ -328,7 +326,6 @@ select case
                 cast(null as varchar2(18 char)) as parent_statement_type,
                 cast(null as varchar2(32 char)) as parent_statement_signature,
                 cast(null as number) as parent_statement_path_len,
-                cast(null as varchar2(3 char)) as is_def_child_of_decl,
                 origin_con_id
            from ids
           where usage_context_id = 0  -- top-level identifiers
@@ -423,19 +420,6 @@ select case
                    else
                       tree.parent_statement_path_len
                 end as parent_statement_path_len,
-                case
-                   when ids.type in ('PROCEDURE', 'FUNCTION')
-                      and ids.usage = 'DEFINITION'
-                   then
-                      case
-                         when tree.usage = 'DECLARATION'
-                            and ids.signature = tree.signature
-                         then
-                            'YES'
-                         else
-                            'NO'
-                      end
-                end as is_def_child_of_decl,
                 ids.origin_con_id
            from tree
            join ids
@@ -444,7 +428,7 @@ select case
             and tree.object_name = ids.object_name
             and tree.usage_id = ids.usage_context_id
       ) cycle owner, object_type, object_name, usage_id set is_cycle to 'Y' default 'N',
-      -- add the columns name_usage, is_new_proc to the list of identifiers
+      -- add the name_usage column to the list of identifiers
       tree_plus as (
          select tree.*,                                                 -- @formatter:off
                 case
@@ -454,159 +438,73 @@ select case
                       tree.type || ' statement'
                    else
                       tree.name || ' (' || lower(tree.type) || ' ' || lower(tree.usage) || ')'
-                end as name_usage,                                      -- @formatter:on
-                case
-                   when type in ('PROCEDURE', 'FUNCTION')
-                      and usage = 'DEFINITION'
-                      and nvl(
-                         lag(
-                            procedure_signature,
-                            case is_def_child_of_decl
-                               when 'YES' then
-                                  2
-                               else
-                                  1
-                            end
-                         ) over (
-                            partition by tree.owner, tree.object_type, tree.object_name
-                            order by usage_id asc
-                         ),
-                         '----'
-                      ) != procedure_signature
-                   then
-                      'YES'
-                end as is_new_proc
+                end as name_usage                                    -- @formatter:on
            from tree
       ),
-   plscope_identifiers as (
-   -- add indent to column name_usage, fix column usage and adds the columns text, is_used,
-   -- proc_ends_before_line, proc_ends_before_col, ref_line, ref_col to the list of identifiers
-   select tree.owner,
-          tree.object_type,
-          tree.object_name,
-          tree.line,
-          tree.col,
-          tree.procedure_name,
-          tree.procedure_scope,
-          cast(
-             -- left indent name_usage according to path_len, wrapping to the left
-             -- if necessary so as not to exceed a limit of 250 characters
-             case
-                when mod(2 * (tree.path_len - 1), 250) + length(tree.name_usage) <= 250 then
-                   lpad(' ', mod(2 * (tree.path_len - 1), 250)) || tree.name_usage
-                else
-                   substr(tree.name_usage, 250 - mod(2 * (tree.path_len - 1), 250)
-                      - length(tree.name_usage))
-                   || lpad(' ', 250 - length(tree.name_usage))
-                   || substr(tree.name_usage, 1, 250 - mod(2 * (tree.path_len - 1), 250))
-             end
-             as varchar2(250 char)
-          ) as name_usage,
-          tree.name,
-          tree.name_path,
-          tree.path_len,
-          tree.type,
-          case
-             -- make SQL_ID and SQL_STMT pseudo-usages appear as EXECUTE
-             when tree.usage in ('SQL_ID', 'SQL_STMT') then
-                'EXECUTE'
-             else
-                tree.usage
-          end as usage,
-          refs.owner as ref_owner,                 -- decl_owner
-          refs.object_type as ref_object_type,     -- decl_object_type
-          refs.object_name as ref_object_name,     -- decl_object_name
-          regexp_replace(src.text, chr(10) || '+$', null) as text,  -- remove trailing new line character
-          tree.parent_statement_type,
-          tree.parent_statement_signature,
-          tree.parent_statement_path_len,
-          case
-             -- wrong result, if used in statements which do not register usage,
-             -- such as a variable for dynamic_sql_stmt in EXECUTE IMMEDIATE.
-             -- Bug 26351814.
-             when tree.object_type in ('PACKAGE BODY', 'PROCEDURE', 'FUNCTION', 'TYPE BODY')
-                and tree.usage = 'DECLARATION'
-                and tree.type not in ('LABEL')
-             then
+      plscope_identifiers as (
+         -- add indent to column name_usage, fix column usage, and add the text, ref_line,
+         -- and ref_col columns to the list of identifiers
+         select tree.owner,
+                tree.object_type,
+                tree.object_name,
+                tree.line,
+                tree.col,
+                tree.procedure_name,
+                tree.procedure_scope,
+                cast(
+                   -- left indent name_usage according to path_len, wrapping to the left
+                   -- if necessary so as not to exceed a limit of 250 characters
+                   case
+                      when mod(2 * (tree.path_len - 1), 250) + length(tree.name_usage) <= 250 then
+                         lpad(' ', mod(2 * (tree.path_len - 1), 250)) || tree.name_usage
+                      else
+                         substr(tree.name_usage, 250 - mod(2 * (tree.path_len - 1), 250)
+                            - length(tree.name_usage))
+                         || lpad(' ', 250 - length(tree.name_usage))
+                         || substr(tree.name_usage, 1, 250 - mod(2 * (tree.path_len - 1), 250))
+                   end
+                   as varchar2(250 char)
+                ) as name_usage,
+                tree.name,
+                tree.name_path,
+                tree.path_len,
+                tree.type,
                 case
-                   when count(
-                         case
-                            when tree.usage not in ('DECLARATION', 'ASSIGNMENT')
-                               or (tree.type in ('FORMAL OUT', 'FORMAL IN OUT')
-                                  and tree.usage = 'ASSIGNMENT')
-                            then
-                               1
-                         end
-                      ) over (
-                         partition by tree.owner, tree.object_name, tree.object_type, tree.signature
-                      ) = 0
-                   then
-                      'NO'
+                   -- make SQL_ID and SQL_STMT pseudo-usages appear as EXECUTE
+                   when tree.usage in ('SQL_ID', 'SQL_STMT') then
+                      'EXECUTE'
                    else
-                      'YES'
-                end
-          end as is_used,
-          tree.signature,
-          tree.usage_id,
-          tree.usage_context_id,
-          tree.is_fixed_context_id,
-          tree.procedure_signature,
-          --tree.is_def_child_of_decl,    --uncomment if needed for debugging
-          --tree.is_new_proc,             --uncomment if needed for debugging
-          case
-             when tree.is_new_proc = 'YES' then
-                coalesce(
-                   first_value(
-                      case
-                         when tree.is_new_proc = 'YES'
-                            or tree.usage_context_id = 1
-                         then
-                            tree.line
-                      end
-                   ) ignore nulls over (
-                      partition by tree.owner, tree.object_type, tree.object_name
-                      order by tree.usage_id
-                      rows between 1 following and unbounded following
-                   ),
-                   max(tree.line) over (
-                         partition by tree.owner, tree.object_type, tree.object_name
-                   ) + 1
-                )
-          end as proc_ends_before_line,
-          case
-             when tree.is_new_proc = 'YES' then
-                nvl(
-                   first_value(
-                      case
-                         when tree.is_new_proc = 'YES'
-                            or tree.usage_context_id = 1
-                         then
-                            tree.col
-                      end
-                   ) ignore nulls over (
-                      partition by tree.owner, tree.object_type, tree.object_name
-                      order by tree.usage_id
-                      rows between 1 following and unbounded following
-                   ),
-                   1
-                )
-          end as proc_ends_before_col,
-          refs.line as ref_line,         -- decl_line
-          refs.col as ref_col,           -- decl_col
-          tree.origin_con_id
-     from tree_plus tree
-     left join sys.all_identifiers refs -- must not used pls_ids to consider all identifiers
-       on refs.signature = tree.signature
-      and refs.usage = 'DECLARATION'
-     left join src
-       on src.owner = tree.owner
-      and src.type = tree.object_type
-      and src.name = tree.object_name
-      and src.line = tree.line
+                      tree.usage
+                end as usage,
+                refs.owner as ref_owner,                 -- decl_owner
+                refs.object_type as ref_object_type,     -- decl_object_type
+                refs.object_name as ref_object_name,     -- decl_object_name
+                regexp_replace(src.text, chr(10) || '+$', null) as text,  -- remove trailing new line character
+                tree.parent_statement_type,
+                tree.parent_statement_signature,
+                tree.parent_statement_path_len,
+                tree.signature,
+                tree.usage_id,
+                tree.usage_context_id,
+                tree.is_fixed_context_id,
+                tree.procedure_signature,
+                refs.line as ref_line,         -- decl_line
+                refs.col as ref_col,           -- decl_col
+                tree.origin_con_id
+           from tree_plus tree
+           left join sys.all_identifiers refs -- must not used pls_ids to consider all identifiers
+             on refs.signature = tree.signature
+            and refs.usage = 'DECLARATION'
+           left join src
+             on src.owner = tree.owner
+            and src.type = tree.object_type
+            and src.name = tree.object_name
+            and src.line = tree.line
       )
 -- the with clause is based on relational view "plscope_identifiers" with the following minimal changes:
 --     - filter on "owner like nvl(:OBJECT_OWNER, user)" instead of plscope context variables
 --     - replace "dba_" with "sys._all_" to make the query work with and without dba rights
+--     - removal of a couple of columns which are unlikely to be used here
 -- producing a list of SQL statements with user-defined function calls
 select case
           when object_type in ('FUNCTION', 'PACKAGE', 'PACKAGE BODY', 'PROCEDURE', 'TRIGGER', 'TYPE', 'TYPE BODY') then
@@ -1000,13 +898,13 @@ with
    tree_plus as (
       select tree.*,                                                 -- @formatter:off
              case
-                   when tree.usage = 'SQL_ID' then
-                      tree.type || ' statement (sql_id: ' || tree.name || ')'
-                   when tree.usage = 'SQL_STMT' then
-                      tree.type || ' statement'
-                   else
-                      tree.name || ' (' || lower(tree.type) || ' ' || lower(tree.usage) || ')'
-                end as name_usage                                    -- @formatter:on
+                when tree.usage = 'SQL_ID' then
+                   tree.type || ' statement (sql_id: ' || tree.name || ')'
+                when tree.usage = 'SQL_STMT' then
+                   tree.type || ' statement'
+                else
+                   tree.name || ' (' || lower(tree.type) || ' ' || lower(tree.usage) || ')'
+             end as name_usage                                    -- @formatter:on
         from tree
    ),
    plscope_identifiers as (
@@ -1484,8 +1382,7 @@ with
    ),
    -- recursive with clause to extend the list of identifiers with the columns
    -- procedure_name, procedure_scope, name_path, path_len (level), procedure_signature,
-   -- parent_statement_type, parent_statement_signature, parent_statement_path_len,
-   -- is_def_child_of_decl
+   -- parent_statement_type, parent_statement_signature, parent_statement_path_len
    tree (
       owner,
       object_type,
@@ -1508,7 +1405,6 @@ with
       parent_statement_type,
       parent_statement_signature,
       parent_statement_path_len,
-      is_def_child_of_decl,
       origin_con_id
    ) as (
       select owner,
@@ -1541,7 +1437,6 @@ with
              cast(null as varchar2(18 char)) as parent_statement_type,
              cast(null as varchar2(32 char)) as parent_statement_signature,
              cast(null as number) as parent_statement_path_len,
-             cast(null as varchar2(3 char)) as is_def_child_of_decl,
              origin_con_id
         from ids
        where usage_context_id = 0  -- top-level identifiers
@@ -1636,19 +1531,6 @@ with
                 else
                    tree.parent_statement_path_len
              end as parent_statement_path_len,
-             case
-                when ids.type in ('PROCEDURE', 'FUNCTION')
-                   and ids.usage = 'DEFINITION'
-                then
-                   case
-                      when tree.usage = 'DECLARATION'
-                         and ids.signature = tree.signature
-                      then
-                         'YES'
-                      else
-                         'NO'
-                   end
-             end as is_def_child_of_decl,
              ids.origin_con_id
         from tree
         join ids
@@ -1657,43 +1539,22 @@ with
          and tree.object_name = ids.object_name
          and tree.usage_id = ids.usage_context_id
    ) cycle owner, object_type, object_name, usage_id set is_cycle to 'Y' default 'N',
-   -- add the columns name_usage, is_new_proc to the list of identifiers
+   -- add the name_usage column to the list of identifiers
    tree_plus as (
       select tree.*,                                                 -- @formatter:off
              case
-                   when tree.usage = 'SQL_ID' then
-                      tree.type || ' statement (sql_id: ' || tree.name || ')'
-                   when tree.usage = 'SQL_STMT' then
-                      tree.type || ' statement'
-                   else
-                      tree.name || ' (' || lower(tree.type) || ' ' || lower(tree.usage) || ')'
-                end as name_usage,                                      -- @formatter:on
-             case
-                when type in ('PROCEDURE', 'FUNCTION')
-                   and usage = 'DEFINITION'
-                   and nvl(
-                      lag(
-                         procedure_signature,
-                         case is_def_child_of_decl
-                            when 'YES' then
-                               2
-                            else
-                               1
-                         end
-                      ) over (
-                         partition by tree.owner, tree.object_type, tree.object_name
-                         order by usage_id asc
-                      ),
-                      '----'
-                   ) != procedure_signature
-                then
-                   'YES'
-             end as is_new_proc
+                when tree.usage = 'SQL_ID' then
+                   tree.type || ' statement (sql_id: ' || tree.name || ')'
+                when tree.usage = 'SQL_STMT' then
+                   tree.type || ' statement'
+                else
+                   tree.name || ' (' || lower(tree.type) || ' ' || lower(tree.usage) || ')'
+             end as name_usage                                       -- @formatter:on
         from tree
    ),
    plscope_identifiers as (
-      -- add indent to column name_usage, fix column usage and adds the columns text, is_used,
-      -- proc_ends_before_line, proc_ends_before_col, ref_line, ref_col to the list of identifiers
+      -- add indent to column name_usage, fix column usage, and add the text, is_used,
+      -- ref_line, and ref_col columns to the list of identifiers
       select tree.owner,
              tree.object_type,
              tree.object_name,
@@ -1764,46 +1625,6 @@ with
              tree.usage_context_id,
              tree.is_fixed_context_id,
              tree.procedure_signature,
-             --tree.is_def_child_of_decl,    --uncomment if needed for debugging
-             --tree.is_new_proc,             --uncomment if needed for debugging
-             case
-                when tree.is_new_proc = 'YES' then
-                   coalesce(
-                      first_value(
-                         case
-                            when tree.is_new_proc = 'YES'
-                               or tree.usage_context_id = 1
-                            then
-                               tree.line
-                         end
-                      ) ignore nulls over (
-                         partition by tree.owner, tree.object_type, tree.object_name
-                         order by tree.usage_id
-                         rows between 1 following and unbounded following
-                      ),
-                      max(tree.line) over (
-                            partition by tree.owner, tree.object_type, tree.object_name
-                      ) + 1
-                   )
-             end as proc_ends_before_line,
-             case
-                when tree.is_new_proc = 'YES' then
-                   nvl(
-                      first_value(
-                         case
-                            when tree.is_new_proc = 'YES'
-                               or tree.usage_context_id = 1
-                            then
-                               tree.col
-                         end
-                      ) ignore nulls over (
-                         partition by tree.owner, tree.object_type, tree.object_name
-                         order by tree.usage_id
-                         rows between 1 following and unbounded following
-                      ),
-                      1
-                   )
-             end as proc_ends_before_col,
              refs.line as ref_line,         -- decl_line
              refs.col as ref_col,           -- decl_col
              tree.origin_con_id
@@ -1820,6 +1641,7 @@ with
 -- the with clause is based on relational view "plscope_identifiers" with the following minimal changes:
 --     - filter on "owner like nvl(:OBJECT_OWNER, user)" instead of plscope context variables
 --     - replace "dba_" with "sys._all_" to make the query work with and without dba rights
+--     - removal of a couple of columns which are unlikely to be used here
 -- producing a list of unused local identifiers
 select case
           when object_type in ('FUNCTION', 'PACKAGE', 'PACKAGE BODY', 'PROCEDURE', 'TRIGGER', 'TYPE', 'TYPE BODY') then
@@ -1874,7 +1696,7 @@ with
              name,
              line,
              text
-        from sys.all_source
+        from sys.all_source -- NOSONAR: avoid public synonym
        where owner like nvl(:OBJECT_OWNER, user)
    ),
    -- PL/SQL identifiers filtered by user
@@ -1892,7 +1714,7 @@ with
              col,
              usage_context_id,
              0 as origin_con_id
-        from sys.all_identifiers
+        from sys.all_identifiers -- NOSONAR: avoid public synonym
        where owner like nvl(:OBJECT_OWNER, user)
    ),
    -- full list of identifiers (PL/SQL and SQL) with columns is_sql_stmt and procedure_scope
@@ -1918,7 +1740,6 @@ with
          and sig.object_name = pls_ids.object_name
          and sig.usage = 'DECLARATION'
          and sig.signature = pls_ids.signature
-       where pls_ids.owner like nvl(:OBJECT_OWNER, user)
    ),
    -- add column sane_fk to list of identifiers
    base_ids as (
@@ -1987,8 +1808,7 @@ with
    ),
    -- recursive with clause to extend the list of identifiers with the columns
    -- procedure_name, procedure_scope, name_path, path_len (level), procedure_signature,
-   -- parent_statement_type, parent_statement_signature, parent_statement_path_len,
-   -- is_def_child_of_decl
+   -- parent_statement_type, parent_statement_signature, parent_statement_path_len
    tree (
       owner,
       object_type,
@@ -2011,7 +1831,6 @@ with
       parent_statement_type,
       parent_statement_signature,
       parent_statement_path_len,
-      is_def_child_of_decl,
       origin_con_id
    ) as (
       select owner,
@@ -2044,7 +1863,6 @@ with
              cast(null as varchar2(18)) as parent_statement_type,
              cast(null as varchar2(32)) as parent_statement_signature,
              cast(null as number) as parent_statement_path_len,
-             cast(null as varchar2(3)) as is_def_child_of_decl,
              origin_con_id
         from ids
        where usage_context_id = 0  -- top-level identifiers
@@ -2139,19 +1957,6 @@ with
                 else
                    tree.parent_statement_path_len
              end as parent_statement_path_len,
-             case
-                when ids.type in ('PROCEDURE', 'FUNCTION')
-                   and ids.usage = 'DEFINITION'
-                then
-                   case
-                      when tree.usage = 'DECLARATION'
-                         and ids.signature = tree.signature
-                      then
-                         'YES'
-                      else
-                         'NO'
-                   end
-             end as is_def_child_of_decl,
              ids.origin_con_id
         from tree
         join ids
@@ -2160,7 +1965,7 @@ with
          and tree.object_name = ids.object_name
          and tree.usage_id = ids.usage_context_id
    ) cycle owner, object_type, object_name, usage_id set is_cycle to 'Y' default 'N',
-   -- add the columns name_usage, is_new_proc to the list of identifiers
+   -- add the name_usage column to the list of identifiers
    tree_plus as (
       select tree.*,                                                 -- @formatter:off
              case
@@ -2170,32 +1975,11 @@ with
                    tree.type || ' statement'
                 else
                    tree.name || ' (' || lower(tree.type) || ' ' || lower(tree.usage) || ')'
-             end as name_usage,                                      -- @formatter:on
-             case
-                when type in ('PROCEDURE', 'FUNCTION')
-                   and usage = 'DEFINITION'
-                   and nvl(
-                      lag(
-                         procedure_signature,
-                         case is_def_child_of_decl
-                            when 'YES' then
-                               2
-                            else
-                               1
-                         end
-                      ) over (
-                         partition by tree.owner, tree.object_type, tree.object_name
-                         order by usage_id asc
-                      ),
-                      '----'
-                   ) != procedure_signature
-                then
-                   'YES'
-             end as is_new_proc
+             end as name_usage                                       -- @formatter:on
         from tree
    ),
-   -- add indent to column name_usage, fix column usage and adds the columns text, is_used,
-   -- proc_ends_before_line, proc_ends_before_col, ref_line, ref_col to the list of identifiers
+   -- add indent to column name_usage, fix column usage, and add the text, is_used,
+   -- ref_line, and ref_col columns to the list of identifiers
    plscope_identifiers as (
       select tree.owner,
              tree.object_type,
@@ -2267,46 +2051,6 @@ with
              tree.usage_context_id,
              tree.is_fixed_context_id,
              tree.procedure_signature,
-             --tree.is_def_child_of_decl,    --uncomment if needed for debugging
-             --tree.is_new_proc,             --uncomment if needed for debugging
-             case
-                when tree.is_new_proc = 'YES' then
-                   coalesce(
-                      first_value(
-                         case
-                            when tree.is_new_proc = 'YES'
-                               or tree.usage_context_id = 1
-                            then
-                               tree.line
-                         end
-                      ) ignore nulls over (
-                         partition by tree.owner, tree.object_type, tree.object_name
-                         order by tree.usage_id
-                         rows between 1 following and unbounded following
-                      ),
-                      max(tree.line) over (
-                            partition by tree.owner, tree.object_type, tree.object_name
-                      ) + 1
-                   )
-             end as proc_ends_before_line,
-             case
-                when tree.is_new_proc = 'YES' then
-                   nvl(
-                      first_value(
-                         case
-                            when tree.is_new_proc = 'YES'
-                               or tree.usage_context_id = 1
-                            then
-                               tree.col
-                         end
-                      ) ignore nulls over (
-                         partition by tree.owner, tree.object_type, tree.object_name
-                         order by tree.usage_id
-                         rows between 1 following and unbounded following
-                      ),
-                      1
-                   )
-             end as proc_ends_before_col,
              refs.line as ref_line,         -- decl_line
              refs.col as ref_col,           -- decl_col
              tree.origin_con_id
@@ -2324,6 +2068,7 @@ with
 --     - filter on "owner like nvl(:OBJECT_OWNER, user)" instead of plscope context variables
 --     - replace "dba_" with "sys._all_" to make the query work with and without dba rights
 --     - named query fids is based on PL/SQL identifiers only (no SQL identifiers available in 11.1)
+--     - removal of a couple of columns which are unlikely to be used here
 --     - origin_con_id is set to zero (no multi-tenant option available in 11.1)
 -- producing a list of unused local identifiers
 select case

--- a/sqldev/src/main/resources/com/salvis/plscope/sqldev/report/plscope-utils-reports.xml
+++ b/sqldev/src/main/resources/com/salvis/plscope/sqldev/report/plscope-utils-reports.xml
@@ -1069,7 +1069,7 @@ with
          and src.name = tree.object_name
          and src.line = tree.line
    ),
-   identifiers as ( 
+   table_usage_ids as ( 
       select /*+ materialize */
              ids.owner,
              ids.object_type,
@@ -1106,7 +1106,7 @@ with
              ids.ref_object_type,
              ids.ref_object_name,
              0
-        from identifiers ids
+        from table_usage_ids ids
        where ids.ref_object_type in ('VIEW', 'TABLE', 'SYNONYM')
        union all
       -- indirect dependencies
@@ -1214,7 +1214,7 @@ with
                    'NO'
              end as direct_dependency,
              dep.is_base_object
-        from identifiers ids
+        from table_usage_ids ids
         join dep_trans_closure dep
           on dep.owner = ids.ref_owner
          and dep.type = ids.ref_object_type

--- a/sqldev/src/main/resources/com/salvis/plscope/sqldev/report/plscope-utils-reports.xml
+++ b/sqldev/src/main/resources/com/salvis/plscope/sqldev/report/plscope-utils-reports.xml
@@ -1117,6 +1117,8 @@ with
           on dep.owner = ids.ref_owner
          and dep.type = ids.ref_object_type
          and dep.name = ids.ref_object_name
+         and (dep.ref_type <> 'SYNONYM'     -- ignore synonyms unless directly referenced
+                or dep.path_len = 0)
          and dep.base_obj_type is not null  -- drop syn. refs not leading to tables/views
         left join sys.all_statements refs   -- NOSONAR: avoid public synonym
           on refs.signature = ids.parent_statement_signature   

--- a/sqldev/src/main/resources/com/salvis/plscope/sqldev/report/plscope-utils-reports.xml
+++ b/sqldev/src/main/resources/com/salvis/plscope/sqldev/report/plscope-utils-reports.xml
@@ -839,8 +839,7 @@ with
    ),
    -- recursive with clause to extend the list of identifiers with the columns
    -- procedure_name, procedure_scope, name_path, path_len (level), procedure_signature,
-   -- parent_statement_type, parent_statement_signature, parent_statement_path_len,
-   -- is_def_child_of_decl
+   -- parent_statement_type, parent_statement_signature, parent_statement_path_len
    tree (
       owner,
       object_type,
@@ -863,7 +862,6 @@ with
       parent_statement_type,
       parent_statement_signature,
       parent_statement_path_len,
-      is_def_child_of_decl,
       origin_con_id
    ) as (
       select owner,
@@ -896,7 +894,6 @@ with
              cast(null as varchar2(18 char)) as parent_statement_type,
              cast(null as varchar2(32 char)) as parent_statement_signature,
              cast(null as number) as parent_statement_path_len,
-             cast(null as varchar2(3 char)) as is_def_child_of_decl,
              origin_con_id
         from ids
        where usage_context_id = 0  -- top-level identifiers
@@ -991,19 +988,6 @@ with
                 else
                    tree.parent_statement_path_len
              end as parent_statement_path_len,
-             case
-                when ids.type in ('PROCEDURE', 'FUNCTION')
-                   and ids.usage = 'DEFINITION'
-                then
-                   case
-                      when tree.usage = 'DECLARATION'
-                         and ids.signature = tree.signature
-                      then
-                         'YES'
-                      else
-                         'NO'
-                   end
-             end as is_def_child_of_decl,
              ids.origin_con_id
         from tree
         join ids
@@ -1012,7 +996,7 @@ with
          and tree.object_name = ids.object_name
          and tree.usage_id = ids.usage_context_id
    ) cycle owner, object_type, object_name, usage_id set is_cycle to 'Y' default 'N',
-   -- add the columns name_usage, is_new_proc to the list of identifiers
+   -- add the name_usage column to the list of identifiers
    tree_plus as (
       select tree.*,                                                 -- @formatter:off
              case
@@ -1022,33 +1006,12 @@ with
                       tree.type || ' statement'
                    else
                       tree.name || ' (' || lower(tree.type) || ' ' || lower(tree.usage) || ')'
-                end as name_usage,                                      -- @formatter:on
-             case
-                when type in ('PROCEDURE', 'FUNCTION')
-                   and usage = 'DEFINITION'
-                   and nvl(
-                      lag(
-                         procedure_signature,
-                         case is_def_child_of_decl
-                            when 'YES' then
-                               2
-                            else
-                               1
-                         end
-                      ) over (
-                         partition by tree.owner, tree.object_type, tree.object_name
-                         order by usage_id asc
-                      ),
-                      '----'
-                   ) != procedure_signature
-                then
-                   'YES'
-             end as is_new_proc
+                end as name_usage                                    -- @formatter:on
         from tree
    ),
    plscope_identifiers as (
-      -- add indent to column name_usage, fix column usage and adds the columns text, is_used,
-      -- proc_ends_before_line, proc_ends_before_col, ref_line, ref_col to the list of identifiers
+      -- add indent to column name_usage, fix column usage, and add the text, ref_line,
+      -- and ref_col columns to the list of identifiers
       select tree.owner,
              tree.object_type,
              tree.object_name,
@@ -1075,7 +1038,7 @@ with
              tree.path_len,
              tree.type,
              case
-                   -- make SQL_ID and SQL_STMT pseudo-usages appear as EXECUTE
+                -- make SQL_ID and SQL_STMT pseudo-usages appear as EXECUTE
                 when tree.usage in ('SQL_ID', 'SQL_STMT') then
                    'EXECUTE'
                 else
@@ -1088,77 +1051,11 @@ with
              tree.parent_statement_type,
              tree.parent_statement_signature,
              tree.parent_statement_path_len,
-             case
-                   -- wrong result, if used in statements which do not register usage,
-                   -- such as a variable for dynamic_sql_stmt in EXECUTE IMMEDIATE.
-                   -- Bug 26351814.
-                when tree.object_type in ('PACKAGE BODY', 'PROCEDURE', 'FUNCTION', 'TYPE BODY')
-                   and tree.usage = 'DECLARATION'
-                   and tree.type not in ('LABEL')
-                then
-                   case
-                      when count(
-                            case
-                               when tree.usage not in ('DECLARATION', 'ASSIGNMENT')
-                                  or (tree.type in ('FORMAL OUT', 'FORMAL IN OUT')
-                                     and tree.usage = 'ASSIGNMENT')
-                               then
-                                  1
-                            end
-                         ) over (
-                            partition by tree.owner, tree.object_name, tree.object_type, tree.signature
-                         ) = 0
-                      then
-                         'NO'
-                      else
-                         'YES'
-                   end
-             end as is_used,
              tree.signature,
              tree.usage_id,
              tree.usage_context_id,
              tree.is_fixed_context_id,
              tree.procedure_signature,
-             --tree.is_def_child_of_decl,    --uncomment if needed for debugging
-             --tree.is_new_proc,             --uncomment if needed for debugging
-             case
-                when tree.is_new_proc = 'YES' then
-                   coalesce(
-                      first_value(
-                         case
-                            when tree.is_new_proc = 'YES'
-                               or tree.usage_context_id = 1
-                            then
-                               tree.line
-                         end
-                      ) ignore nulls over (
-                         partition by tree.owner, tree.object_type, tree.object_name
-                         order by tree.usage_id
-                         rows between 1 following and unbounded following
-                      ),
-                      max(tree.line) over (
-                            partition by tree.owner, tree.object_type, tree.object_name
-                      ) + 1
-                   )
-             end as proc_ends_before_line,
-             case
-                when tree.is_new_proc = 'YES' then
-                   nvl(
-                      first_value(
-                         case
-                            when tree.is_new_proc = 'YES'
-                               or tree.usage_context_id = 1
-                            then
-                               tree.col
-                         end
-                      ) ignore nulls over (
-                         partition by tree.owner, tree.object_type, tree.object_name
-                         order by tree.usage_id
-                         rows between 1 following and unbounded following
-                      ),
-                      1
-                   )
-             end as proc_ends_before_col,
              refs.line as ref_line,         -- decl_line
              refs.col as ref_col,           -- decl_col
              tree.origin_con_id

--- a/sqldev/src/main/resources/com/salvis/plscope/sqldev/report/plscope-utils-reports.xml
+++ b/sqldev/src/main/resources/com/salvis/plscope/sqldev/report/plscope-utils-reports.xml
@@ -1172,91 +1172,130 @@ with
          and src.name = tree.object_name
          and src.line = tree.line
    ),
-   dep as (
-      select owner as owner,
-             'TABLE' as type,
-             table_name as name,
-             null as referenced_owner,
-             null as referenced_type,
-             null as referenced_name
-        from sys.all_tables -- NOSONAR: avoid public synonym
-      union all
-      select owner,
-             type,
-             name,
-             referenced_owner,
-             referenced_type,
-             referenced_name
-        from sys.all_dependencies -- NOSONAR: avoid public synonym
-       where type in ('VIEW', 'MATERIALIZED VIEW', 'SYNONYM')
+   identifiers as ( 
+      select /*+ materialize */
+             ids.owner,
+             ids.object_type,
+             ids.object_name,
+             ids.procedure_name,
+             ids.usage,
+             ids.line,
+             ids.col,
+             ids.ref_owner,
+             ids.ref_object_type,
+             ids.ref_object_name,
+             ids.parent_statement_signature
+        from plscope_identifiers ids
+       where ids.type in ('VIEW', 'TABLE', 'SYNONYM')
    ),
-   -- recursive with clause to calculate ref_object_type_path
-   dep_graph_base (
+   -- direct and indirect dependencies; path_len = 0 for direct dependencies, 
+   -- otherwise the length of the dependency chain, i.e. level - 1; cycles are
+   -- possible here (with help from synonyms) so we need to detect them
+   dep_chains (
       owner,
-      object_type,
-      object_name,
+      type,
+      name,
       ref_owner,
-      ref_object_type,
-      ref_object_name,
-      ref_object_type_path,
+      ref_type,
+      ref_name,
       path_len
    ) as (
+      -- direct dependencies
+      select distinct
+             ids.ref_owner,
+             ids.ref_object_type,
+             ids.ref_object_name,
+             ids.ref_owner,
+             ids.ref_object_type,
+             ids.ref_object_name,
+             0
+        from identifiers ids
+       where ids.ref_object_type in ('VIEW', 'TABLE', 'SYNONYM')
+       union all
+      -- indirect dependencies
+      select /*+ no_merge(dep) */ 
+             par.owner,
+             par.type,
+             par.name,
+             dep.referenced_owner,
+             dep.referenced_type,
+             dep.referenced_name,
+             par.path_len + 1
+        from dep_chains par
+        join sys.all_dependencies dep  -- NOSONAR: avoid public synonym
+          on par.ref_owner = dep.owner
+         and par.ref_type = dep.type
+         and par.ref_name = dep.name
+       where par.ref_type <> 'VIEW'    -- don't resolve table usages in views
+         and dep.referenced_type in (  -- list of referenced types of interest
+                'VIEW', 
+                'TABLE', 
+                'SYNONYM',
+                'MATERIALIZED VIEW'    -- does MATERIALIZED VIEW belong here?
+             )
+   )
+   cycle ref_owner, ref_type, ref_name set is_cycle to 'Y' default 'N',
+   -- eliminate duplicate dependencies, keeping the minimum path_len; add the 
+   -- base_object_type column, which is the type of the first object (if any)
+   -- which is not a synonym, in case we're going down a chain of synonyms;
+   -- the is_base_object flag is set to 'YES' for that object, otherwise null
+   dep_trans_closure as (
       select owner,
              type,
              name,
-             owner as ref_owner,
-             type as ref_object_type,
-             name as ref_object_name,
-             '/' || type as ref_object_type_path,
-             1 as path_len
-        from dep
-      union all
-      select dep.owner,
-             dep.type,
-             dep.name,
-             dep_graph_base.ref_owner,
-             dep_graph_base.ref_object_type,
-             dep_graph_base.ref_object_name,
-             case
-                when lengthb(dep_graph_base.ref_object_type_path) + lengthb('/') + lengthb(dep.type) <= 4000 then
-                   dep_graph_base.ref_object_type_path
-                   || '/'
-                   || dep.type
-                else
-                   -- prevent ref_object_type_path from overflowing: keep the first 3 elements, then
-                   -- remove enough elements to accomodate "..." + "/" + the tail end
-                   regexp_substr(dep_graph_base.ref_object_type_path, '^(/([^/]+/){3})')
-                   || '...'
-                   || regexp_replace(
-                      substr(dep_graph_base.ref_object_type_path, instr(dep_graph_base.ref_object_type_path, '/', 1, 4) + 1
-                         + lengthb('.../') + lengthb(dep.type)),
-                      '^[^/]*')
-                   || '/'
-                   || dep.type
-             end as ref_object_type_path,
-             dep_graph_base.path_len + 1 as path_len
-        from dep_graph_base
-        join dep
-          on dep_graph_base.owner = dep.referenced_owner
-         and dep_graph_base.object_type = dep.referenced_type
-         and dep_graph_base.object_name = dep.referenced_name
-   ) cycle owner, object_type, object_name set is_cycle to 'Y' default 'N',
-   -- remove duplicate rows
-   dep_graph as (
-      select distinct
-             owner,
-             object_type,
-             object_name,
              ref_owner,
-             ref_object_type,
-             ref_object_name,
-             ref_object_type_path,
-             path_len
-        from dep_graph_base
+             ref_type,
+             ref_name,
+             min(path_len)  as path_len,
+             nullif(                            -- @formatter:off
+                min(ref_type)
+                keep (
+                   dense_rank first
+                   order by 
+                      case
+                         when ref_type = 'SYNONYM' then
+                            null
+                         else
+                            min(path_len)
+                      end asc nulls last,
+                      min(path_len)
+                )
+                over (
+                   partition by owner, type, name
+                ),
+                'SYNONYM'
+             )  as base_obj_type,               -- @formatter:on
+             case                               -- @formatter:off
+                -- remark: disregarding the case when there are only SYNONYMs in the 
+                -- dependency chain: such chains are filtered out in tab_usage subquery
+                when min(path_len) = min(min(path_len))
+                      keep (
+                         dense_rank first
+                         order by 
+                            case
+                               when ref_type = 'SYNONYM' then
+                                  null
+                               else
+                                  min(path_len)
+                            end asc nulls last,
+                            min(path_len)
+                      )
+                      over (
+                         partition by owner, type, name
+                      ) 
+                then
+                   cast('YES' as varchar2(3 char))
+             end  as is_base_object             -- @formatter:on
+        from dep_chains
+       group by owner,
+             type,
+             name,
+             ref_owner,
+             ref_type,
+             ref_name      
    ),
-   tab_usage as (
-      select /*+use_hash(ids) use_hash(dep_graph) use_hash(refs)*/
-             ids.owner,
+   plscope_tab_usage as (
+      select ids.owner,
              ids.object_type,
              ids.object_name,
              ids.line,
@@ -1268,44 +1307,24 @@ with
                 else
                    ids.usage
              end as operation,
-             dep_graph.ref_owner,
-             dep_graph.ref_object_type,
-             dep_graph.ref_object_name,
+             dep.ref_owner,
+             dep.ref_type  as ref_object_type,
+             dep.ref_name  as ref_object_name,
              case
-                when dep_graph.path_len = 1 then
+                when dep.path_len = 0 then
                    'YES'
                 else
                    'NO'
              end as direct_dependency,
-             dep_graph.ref_object_type_path,
-             lead(dep_graph.ref_object_type_path) over (
-                order by ids.owner, ids.object_type, ids.object_name, ids.line, ids.col, dep_graph.path_len
-             ) as next_ref_object_type_path,
-             ids.text
-        from plscope_identifiers ids
-        join dep_graph
-          on dep_graph.owner = ids.ref_owner
-         and dep_graph.object_type = ids.ref_object_type
-         and dep_graph.object_name = ids.ref_object_name
-        left join sys.all_statements refs -- NOSONAR: avoid public synonym
-          on refs.signature = parent_statement_signature
-       where ids.type in ('VIEW', 'TABLE', 'SYNONYM')
-   ),
-   plscope_tab_usage as (
-      select owner,
-             object_type,
-             object_name,
-             line,
-             col,
-             procedure_name,
-             operation,
-             ref_owner,
-             ref_object_type,
-             ref_object_name,
-             direct_dependency,
-             text
-        from tab_usage
-       where (ref_object_type != 'SYNONYM' or next_ref_object_type_path in ('/VIEW/SYNONYM', '/TABLE/SYNONYM'))
+             dep.is_base_object
+        from identifiers ids
+        join dep_trans_closure dep
+          on dep.owner = ids.ref_owner
+         and dep.type = ids.ref_object_type
+         and dep.name = ids.ref_object_name
+         and dep.base_obj_type is not null  -- drop syn. refs not leading to tables/views
+        left join sys.all_statements refs   -- NOSONAR: avoid public synonym
+          on refs.signature = ids.parent_statement_signature   
    )
 select case
           when object_type in ('FUNCTION', 'PACKAGE', 'PACKAGE BODY', 'PROCEDURE', 'TRIGGER', 'TYPE', 'TYPE BODY') then
@@ -1370,7 +1389,7 @@ select case
            end) as "Reference"
   from plscope_tab_usage
  where operation in ('SELECT', 'INSERT', 'UPDATE', 'DELETE', 'MERGE', 'REFERENCE')
-   and direct_dependency = 'YES'
+   and is_base_object = 'YES'
  group by owner, object_type, object_name, procedure_name, ref_owner, ref_object_type, ref_object_name
  order by owner, object_type, object_name, procedure_name, ref_owner, ref_object_type, ref_object_name
 ]]>


### PR DESCRIPTION
This changes the implementation of the `plscope_tab_usage` view as follows: the dependency graph is now built by following the dependencies in the "usual order", from dependent objects down to referenced objects, rather than the other way around. This may result in working across a smaller subset of dependencies, depending on how big the set of identifiers in the query, thereby making the view slightly faster (hopefully) in practical cases. It also makes handling synonyms, and especially chains of synonyms, easier. 

`plscope_col_usage` has to be changed accordingly, especially as regards ignoring object tables, which may now appear in the result set of `plscope_tab_usage`, but cannot be dealt with properly in `plscope_col_usage` anyway.

The above changes are reflected in corresponding `<display>` elements in SQL Dev viewers/reports.

Additionally, for performance reasons the `plscope_identifiers` CTE in SQL Dev viewers/reports is slightly simplified, by omitting a couple of columns which are unlikely to be ever used in the SQL Dev extension, yet are somewhat costly as they are not eliminated by the query optimizer; this might save up to 15%, which is not completely to be disregarded here.

Last, for completeness, in-depth resolution of chains of synonyms is added to `dd_util.resolve_synonym`.

Thanks & regards,